### PR TITLE
Add hook script capability on droplet start/stop.

### DIFF
--- a/config/dea.yml
+++ b/config/dea.yml
@@ -133,3 +133,10 @@ directory_server:
   logging:
     level: info
 
+# Hook scripts for droplet start/stop
+# hooks:
+#   before_start: path/to/script
+#   after_start: path/to/script
+#   before_stop: path/to/script
+#   after_stop: path/to/script
+

--- a/lib/dea/config.rb
+++ b/lib/dea/config.rb
@@ -73,6 +73,13 @@ module Dea
             optional("dst_path") => String,
             optional("mode")     => enum("ro", "rw"),
           }],
+
+          optional('hooks') => {
+            optional('before_start') => String,
+            optional('after_start')  => String,
+            optional('before_stop')  => String,
+            optional('after_stop')   => String
+          },
         }
       end
     end

--- a/lib/dea/instance.rb
+++ b/lib/dea/instance.rb
@@ -590,6 +590,28 @@ module Dea
       end
     end
 
+    def promise_exec_hook_script(key)
+      Promise.new do |p|
+        if bootstrap.config['hooks'] && bootstrap.config['hooks'][key]
+          script_path = bootstrap.config['hooks'][key]
+          if File.exist?(script_path)
+            script = []
+            script << "umask 077"
+            env = Env.new(self)
+            env.env.each do |k, v|
+              script << "export %s=%s" % [k, v]
+            end
+            script << File.read(script_path)
+            script << "exit"
+            promise_warden_run(:app, script.join("\n")).resolve
+          else
+            logger.warn("The hook(#{key}) script is not found on #{script_path}")
+          end
+        end
+        p.deliver
+      end
+    end
+
     def start(&callback)
       p = Promise.new do
         logger.info("Starting instance")
@@ -626,6 +648,8 @@ module Dea
 
         promise_prepare_start_script.resolve
 
+        promise_exec_hook_script('before_start').resolve
+
         promise_start.resolve
 
         on(Transition.new(:starting, :crashed)) do
@@ -639,6 +663,8 @@ module Dea
         if promise_health_check.resolve
           logger.info("Instance healthy")
           promise_state(State::STARTING, State::RUNNING).resolve
+
+          promise_exec_hook_script('after_start').resolve
         else
           logger.warn("Instance unhealthy")
           p.fail("Instance unhealthy")
@@ -673,9 +699,13 @@ module Dea
 
         promise_state(State::RUNNING, State::STOPPING).resolve
 
+        promise_exec_hook_script('before_stop').resolve
+
         promise_stop.resolve
 
         promise_state(State::STOPPING, State::STOPPED).resolve
+
+        promise_exec_hook_script('after_stop').resolve
 
         p.deliver
       end

--- a/spec/dea/hooks/after_start
+++ b/spec/dea/hooks/after_start
@@ -1,0 +1,1 @@
+echo "after_start"

--- a/spec/dea/hooks/before_start
+++ b/spec/dea/hooks/before_start
@@ -1,0 +1,1 @@
+echo "before_start"

--- a/spec/dea/instance_spec.rb
+++ b/spec/dea/instance_spec.rb
@@ -439,7 +439,9 @@ describe Dea::Instance do
       instance.stub(:promise_setup_environment).and_return(delivering_promise)
       instance.stub(:promise_extract_droplet).and_return(delivering_promise)
       instance.stub(:promise_prepare_start_script).and_return(delivering_promise)
+      instance.stub(:promise_exec_hook_script).with('before_start').and_return(delivering_promise)
       instance.stub(:promise_start).and_return(delivering_promise)
+      instance.stub(:promise_exec_hook_script).with('after_start').and_return(delivering_promise)
       instance.stub(:promise_health_check).and_return(delivering_promise(true))
       instance.stub(:droplet).and_return(droplet)
       instance.stub(:runtime).and_return(runtime)
@@ -861,6 +863,36 @@ describe Dea::Instance do
       end
     end
 
+    describe "before_start hook" do
+      let(:runtime) do
+        runtime = mock(:runtime)
+        runtime.stub(:environment).and_return({})
+        runtime
+      end
+
+      before do
+        bootstrap.stub(:config).and_return({
+          "hooks" => {
+            "before_start" => File.join(File.dirname(__FILE__), 'hooks/before_start')
+          }
+        })
+        instance.stub(:runtime).and_return(runtime)
+        instance.unstub(:promise_exec_hook_script)
+      end
+
+      it "should execute script file" do
+        instance.stub(:promise_warden_run) do |_, script|
+          script.should_not be_empty
+          lines = script.split("\n")
+          lines[-2].should == 'echo "before_start"'  # file contents
+          lines[-1].should == 'exit'
+          delivering_promise
+        end
+
+        expect_start.to_not raise_error
+      end
+    end
+
     describe "starting the application" do
       let(:runtime) do
         runtime = mock("Dea::Runtime")
@@ -934,6 +966,36 @@ describe Dea::Instance do
         expect_start.to raise_error
       end
     end
+
+    describe "after_start hook" do
+      let(:runtime) do
+        runtime = mock(:runtime)
+        runtime.stub(:environment).and_return({})
+        runtime
+      end
+
+      before do
+        bootstrap.stub(:config).and_return({
+          "hooks" => {
+            "after_start" => File.join(File.dirname(__FILE__), 'hooks/after_start')
+          }
+        })
+        instance.stub(:runtime).and_return(runtime)
+        instance.unstub(:promise_exec_hook_script)
+      end
+
+      it "should execute the script file" do
+        instance.stub(:promise_warden_run) do |_, script|
+          script.should_not be_empty
+          lines = script.split("\n")
+          lines[-2].should == 'echo "after_start"'  # file contents
+          lines[-1].should == 'exit'
+          delivering_promise
+        end
+
+        expect_start.to_not raise_error
+      end
+    end
   end
 
   describe "stop transition" do
@@ -942,6 +1004,7 @@ describe Dea::Instance do
     end
 
     before do
+      bootstrap.stub(:config).and_return({})
       instance.stub(:promise_state).and_return(delivering_promise)
       instance.stub(:promise_warden_connection).and_return(delivering_promise(warden_connection))
       instance.stub(:promise_stop).and_return(delivering_promise)


### PR DESCRIPTION
Hook script provide the CF providers to configure warden container based
on their demand. If providers want to start a special process for their purpose (*1)
in droplet container, they can setup it on container_root_fs (of Warden)
by chroot/apt-get combination and start the daemon by hook script.

(*1) e.g:
- Log Collector daemon (flume, fluentd, ...etc),
- Redis proxy daemon (Twemproxy to proxy requests to bound redis services)
- ...

Change-Id: Ic4afc57a8d47b0797b93ce13c108d40a467dd091

(Moved from Gerrit: http://reviews.cloudfoundry.org/#/c/13516)
