### PR TITLE
Fix for CPU stats collection

### DIFF
--- a/lib/dea/instance.rb
+++ b/lib/dea/instance.rb
@@ -719,7 +719,7 @@ module Dea
           :ns_used      => info_resp.cpu_stat.usage,
         }
 
-        @cpu_samples.unshift if @cpu_samples.size > 2
+        @cpu_samples.shift if @cpu_samples.size > 2
 
         if @cpu_samples.size == 2
           used = @cpu_samples[1][:ns_used] - @cpu_samples[0][:ns_used]


### PR DESCRIPTION
The Cpu usage samples will just get bigger and the "@cpu_samples == 2" will never be true. Shifing the array will keep it with 2 elements.

Btw, the newest vmc is expecting to get the Cpu usage as a percentage: https://github.com/cloudfoundry/vmc/blob/0ab038aa4a3ea1609456e2d5a2dce9bf97518ade/lib/vmc/cli/app/stats.rb#L39
Where should the fix be applied, in DEA or VMC?
