### PR TITLE
Use https:// rather than git:// for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "buildpacks/vendor/nodejs"]
 	path = buildpacks/vendor/nodejs
-	url = git://github.com/heroku/heroku-buildpack-nodejs.git
+	url = https://github.com/heroku/heroku-buildpack-nodejs.git
 [submodule "buildpacks/vendor/java"]
 	path = buildpacks/vendor/java
-	url = git://github.com/cloudfoundry/cloudfoundry-buildpack-java.git
+	url = https://github.com/cloudfoundry/cloudfoundry-buildpack-java.git
 [submodule "buildpacks/vendor/ruby"]
 	path = buildpacks/vendor/ruby
-	url = git://github.com/cloudfoundry/heroku-buildpack-ruby.git
+	url = htpps://github.com/cloudfoundry/heroku-buildpack-ruby.git
 [submodule "go/vendor"]
 	path = go/vendor
 	url = https://github.com/cloudfoundry/govendor


### PR DESCRIPTION
To avoid problems with the git protocol's port being blocked by a
firewall, use https URIs for submodules
