### PR TITLE
Hidden files at top level dir missed

### DIFF
--- a/buildpacks/lib/staging_plugin.rb
+++ b/buildpacks/lib/staging_plugin.rb
@@ -140,7 +140,7 @@ echo "$STARTED" >> #{pidfile_dir}/run.pid
     end
 
     def copy_source_files(dest=nil)
-      system "cp -a #{File.join(source_directory, "*")} #{dest || app_dir}"
+      system "cp -a #{File.join(source_directory, ".")} #{dest || app_dir}"
     end
   end
 end


### PR DESCRIPTION
Hidden files are missed in the top level directory due to '*' copy, switching to '.' fixes this.
