### PR TITLE
Clone a single revision

### DIFF
--- a/buildpacks/lib/buildpack.rb
+++ b/buildpacks/lib/buildpack.rb
@@ -29,7 +29,7 @@ module Buildpacks
 
     def clone_buildpack(buildpack_url)
       buildpack_path = "/tmp/buildpacks/#{File.basename(buildpack_url)}"
-      ok = system("git clone #{buildpack_url} #{buildpack_path}")
+      ok = system("git clone --depth 1 #{buildpack_url} #{buildpack_path}")
       raise "Failed to git clone buildpack" unless ok
       Buildpacks::Installer.new(Pathname.new(buildpack_path), app_dir, cache_dir)
     end

--- a/spec/unit/buildpack_spec.rb
+++ b/spec/unit/buildpack_spec.rb
@@ -75,7 +75,7 @@ fi
 
     it "clones the buildpack URL" do
       plugin.should_receive(:system).with(anything) do |cmd|
-        expect(cmd).to match /git clone #{buildpack_url} \/tmp\/buildpacks/
+        expect(cmd).to match /git clone --depth 1 #{buildpack_url} \/tmp\/buildpacks/
         true
       end
 


### PR DESCRIPTION
Previously, when a buildpack was cloned, the entire buildpack repository was fetched.  This resulted in a slower clone than was otherwise necessary.  This change executes the clone with a `--depth 1` which only fetches a single revision and no history.  This results in noticeable speed gains.

| Buildpack | Full | Depth 1 |
| --- | --- | --- |
| `cloudfoundry-buildpack-java` | `2.031s` | `1.451s` |
| `heroku-buildpack-nodejs` | `6.840s` | `1.577s` |
| `heroku-buildpack-ruby` | `5.075s` | `1.785s` |

[#50080879]
