### PR TITLE
Initialize buildpack submodules

### DIFF
--- a/buildpacks/lib/buildpack.rb
+++ b/buildpacks/lib/buildpack.rb
@@ -29,7 +29,7 @@ module Buildpacks
 
     def clone_buildpack(buildpack_url)
       buildpack_path = "/tmp/buildpacks/#{File.basename(buildpack_url)}"
-      ok = system("git clone --depth 1 #{buildpack_url} #{buildpack_path}")
+      ok = system("git clone --depth 1 --recurse-submodules #{buildpack_url} #{buildpack_path}")
       raise "Failed to git clone buildpack" unless ok
       Buildpacks::Installer.new(Pathname.new(buildpack_path), app_dir, cache_dir)
     end

--- a/spec/unit/buildpack_spec.rb
+++ b/spec/unit/buildpack_spec.rb
@@ -75,7 +75,7 @@ fi
 
     it "clones the buildpack URL" do
       plugin.should_receive(:system).with(anything) do |cmd|
-        expect(cmd).to match /git clone --depth 1 #{buildpack_url} \/tmp\/buildpacks/
+        expect(cmd).to match /git clone --depth 1 --recurse-submodules #{buildpack_url} \/tmp\/buildpacks/
         true
       end
 


### PR DESCRIPTION
Previously, when a buildpack was cloned, any submodules containted within that repository were not initialized.  This means that any split of buildpack code across repositories was difficult if not impossible.  This change adds `--recurse-submodules` to the clone command to initialize any declared submodules.

[#50081011]
