### PR TITLE
Support git branch names on buildpacks

### DIFF
--- a/spec/unit/buildpack_spec.rb
+++ b/spec/unit/buildpack_spec.rb
@@ -61,12 +61,12 @@ fi
 
   context "when a buildpack URL is passed" do
     let(:buildpack_url) { "git://github.com/heroku/heroku-buildpack-java.git" }
-    let(:staging_env) { { "buildpack" => buildpack_url } }
+    let(:staging_env) { {"buildpack" => buildpack_url} }
     let(:staging_config) {
       {
-        "source_dir" => ".",
-        "dest_dir" => ".",
-        "environment" => staging_env
+          "source_dir" => ".",
+          "dest_dir" => ".",
+          "environment" => staging_env
       }
     }
     let(:plugin) { Buildpacks::Buildpack.new(staging_config) }
@@ -96,6 +96,20 @@ fi
       it "gives up and raises an error" do
         plugin.stub(:system).with(anything) { false }
         expect { subject }.to raise_error("Failed to git clone buildpack")
+      end
+    end
+
+    context "when specifying a branch" do
+      URL = "git://github.com/heroku/heroku-buildpack-java.git"
+      BRANCH = "branch"
+      let(:buildpack_url) { "#{URL}+#{BRANCH}" }
+
+      it "clones a branch when a branch name is passed in" do
+        plugin.should_receive(:system).with(anything) do |cmd|
+          expect(cmd).to match /git clone --branch #{BRANCH} #{URL} \/tmp\/buildpacks/
+          true
+        end
+        subject
       end
     end
   end
@@ -281,9 +295,9 @@ fi
 
     let(:staging_config) {
       {
-        "source_dir" => ".",
-        "dest_dir" => ".",
-        "environment" => staging_env
+          "source_dir" => ".",
+          "dest_dir" => ".",
+          "environment" => staging_env
       }
     }
     subject { Buildpacks::Buildpack.new(staging_config) }


### PR DESCRIPTION
# Background

During development, users debugging buildpacks often need to push test
commits and then revert them, which messes up the buildpack's git
history. So there is a need to specify a branch name as well as the
git URL of a buildpack.

During production, multiple levels of a given buildpack may be used.
The natural way to manage these is with a git tag rather than a new
git repository for each level. So there is a need to specify a tag
name as well as the git URL of a buildpack.
# Implementation

Support a branch (or tag) name as part of a buildpack git URL. The
syntax of the URL passed to --buildpack will be:

```
<git repository URL>+<branch name>
```

Parse the buildpack parameter into a URL and a branch name and pass
the branch name, if it was specified, to git clone.

Assume that "+" is not part of the URL or the branch name. This is not
impossible, but is very unlikely and is a restriction of this support.

Add a test to exercise the branch name syntax.

[#50081697]
