### PR TITLE
Fix submodule init on clone

### DIFF
--- a/buildpacks/lib/buildpack.rb
+++ b/buildpacks/lib/buildpack.rb
@@ -29,16 +29,8 @@ module Buildpacks
 
     def clone_buildpack(buildpack_url)
       buildpack_path = "/tmp/buildpacks/#{File.basename(buildpack_url)}"
-
-      gitcmd = "git clone"
-      gitcmd << " --depth 1" if buildpack_url =~ /^git/
-
-      ok = system("#{gitcmd} #{buildpack_url} #{buildpack_path}")
+      ok = system("git clone --depth 1 --recursive #{buildpack_url} #{buildpack_path}")
       raise "Failed to git clone buildpack" unless ok
-
-      ok = system("cd #{buildpack_path} && git submodule update --init --recursive")
-      raise "Failed to update submodules" unless ok
-
       Buildpacks::Installer.new(Pathname.new(buildpack_path), app_dir, cache_dir)
     end
 

--- a/spec/unit/buildpack_spec.rb
+++ b/spec/unit/buildpack_spec.rb
@@ -74,13 +74,8 @@ fi
     subject { plugin.build_pack }
 
     it "clones the buildpack URL" do
-      plugin.should_receive(:system).with(/git clone/) do |cmd|
-        expect(cmd).to match /git clone --depth 1 #{buildpack_url} \/tmp\/buildpacks/
-        true
-      end
-
-      plugin.should_receive(:system).with(/git submodule/) do |cmd|
-        expect(cmd).to match /cd \/tmp\/buildpacks\/heroku-buildpack-java.git && git submodule update --init --recursive/
+      plugin.should_receive(:system).with(anything) do |cmd|
+        expect(cmd).to match /git clone --depth 1 --recursive #{buildpack_url} \/tmp\/buildpacks/
         true
       end
 


### PR DESCRIPTION
In a previous pull request, `clone` was changed to initialize and update submodules recursively.  This change used a flag, `--recurse-submodules`, that was added after the version of git being used by the dea.  This flag was actually an alias to `--recursive` which does exist in the version of git used by the dea[1].

The fix made for the previous failure was to split the `clone` command into two calls (`clone`, then change directory and initialize submodules) which was unnecessary.  In addition, this fix added some logic around cloning with `--depth=1` that broke this depth functionality when cloning with `http://` URLs (the default when using GitHub).

This change has the net effect of reverting the changes in 20bcb31275e1605d626fb1869dc9fb8314252dd0 and doing the simplest possible fix for the `--recurse-submodules` change.  Specifically this change rolls back the changes around `--depth=1` as they are not necessary to fix the problem with the unsupported flag and break the functionality that `--depth=1` was intended to provide.

[1] The options clone supports in the version of Git on the dea:

``` plain
-----> Downloaded app package (23M)
-----> Downloaded app buildpack cache (4.0K)
error: unknown option `recurse-submodules'
usage: git clone [options] [--] <repo> [<dir>]

    -q, --quiet           be quiet
    -v, --verbose         be verbose
    --progress            force progress reporting
    -n, --no-checkout     don't create a checkout
    --bare                create a bare repository
    --mirror              create a mirror repository (implies bare)
    -l, --local           to clone from a local repository
    --no-hardlinks        don't use local hardlinks, always copy
    -s, --shared          setup as shared repository
    --recursive           initialize submodules in the clone
    --template <path>     path the template repository
    --reference <repo>    reference repository
    -o, --origin <branch>
                          use <branch> instead of 'origin' to track upstream
    -b, --branch <branch>
                          checkout <branch> instead of the remote's HEAD
    -u, --upload-pack <path>
                          path to git-upload-pack on the remote
    --depth <depth>       create a shallow clone of that depth

/var/vcap/packages/dea_next/buildpacks/lib/buildpack.rb:33:in `clone_buildpack': Failed to git clone buildpack (RuntimeError)
    from /var/vcap/packages/dea_next/buildpacks/lib/buildpack.rb:41:in `build_pack'
    from /var/vcap/packages/dea_next/buildpacks/lib/buildpack.rb:26:in `block in compile_with_timeout'
    from /usr/lib/ruby/1.9.1/timeout.rb:68:in `timeout'
    from /var/vcap/packages/dea_next/buildpacks/lib/buildpack.rb:25:in `compile_with_timeout'
    from /var/vcap/packages/dea_next/buildpacks/lib/buildpack.rb:16:in `block in stage_application'
    from /var/vcap/packages/dea_next/buildpacks/lib/buildpack.rb:12:in `chdir'
    from /var/vcap/packages/dea_next/buildpacks/lib/buildpack.rb:12:in `stage_application'
    from /var/vcap/packages/dea_next/buildpacks/bin/run:10:in `<main>'
```
