### PR TITLE
Ensure file is written in binary mode.

### DIFF
--- a/lib/dea/utils/download.rb
+++ b/lib/dea/utils/download.rb
@@ -26,7 +26,7 @@ class Download
   def download!(&blk)
     FileUtils.mkdir_p(destination_dir)
 
-    file = Tempfile.new("droplet", destination_dir)
+    file = Tempfile.new("droplet", destination_dir, :mode => File::BINARY)
     sha1 = Digest::SHA1.new
 
     http = EM::HttpRequest.new(uri).get


### PR DESCRIPTION
I found this while running the DEA on Windows - the `app.zip` file can't be opened since it's corrupt.
