### PR TITLE
Remove support for droplet.status message

### DIFF
--- a/lib/dea/bootstrap.rb
+++ b/lib/dea/bootstrap.rb
@@ -551,14 +551,6 @@ module Dea
       nil
     end
 
-    def handle_droplet_status(message)
-      instance_registry.each do |instance|
-        next unless instance.starting? || instance.running?
-        resp = Dea::Protocol::V1::DropletStatusResponse.generate(instance)
-        message.respond(resp)
-      end
-    end
-
     def evacuating?
       @evacuation_processed == true
     end

--- a/lib/dea/nats.rb
+++ b/lib/dea/nats.rb
@@ -45,10 +45,6 @@ module Dea
       subscribe("dea.find.droplet") do |message|
         bootstrap.handle_dea_find_droplet(message)
       end
-
-      subscribe("droplet.status") do |message|
-        bootstrap.handle_droplet_status(message)
-      end
     end
 
     def stop

--- a/lib/dea/protocol.rb
+++ b/lib/dea/protocol.rb
@@ -81,18 +81,6 @@ module Dea::Protocol::V1
     end
   end
 
-  class DropletStatusResponse
-    def self.generate(instance)
-      { "name" => instance.application_name,
-        "uris" => instance.application_uris,
-        # TODO: Fill in when available
-        # host
-        # port
-        # uptime
-      }
-    end
-  end
-
   class AdvertiseMessage
     def self.generate(message={})
       { "id" => message[:id],

--- a/spec/unit/nats_spec.rb
+++ b/spec/unit/nats_spec.rb
@@ -21,8 +21,7 @@ describe Dea::Nats do
       "dea.UUID.start"      => :handle_dea_directed_start,
       "dea.stop"            => :handle_dea_stop,
       "dea.update"          => :handle_dea_update,
-      "dea.find.droplet"    => :handle_dea_find_droplet,
-      "droplet.status"      => :handle_droplet_status
+      "dea.find.droplet"    => :handle_dea_find_droplet
     }.each do |subject, method|
       it "should subscribe to #{subject.inspect}" do
         data = { "subject" => subject }


### PR DESCRIPTION
The text 'droplet.status' does not occur anywhere in cf-release currently.

After discussing with some team members, we believe this was a v1
feature that no longer needs to be supported.
