### PR TITLE
Add space_id to instance now that cc_ng is sending it.

### DIFF
--- a/lib/dea/instance.rb
+++ b/lib/dea/instance.rb
@@ -116,7 +116,7 @@ module Dea
       attributes["instance_index"]      ||= attributes.delete("index")
 
       attributes["application_id"]      ||= attributes.delete("droplet").to_s
-      attributes["application_space_id"]||= attributes.delete("space").to_s
+      attributes["tags"]                ||= attributes.delete("tags") { |_| {} }
       attributes["application_version"] ||= attributes.delete("version")
       attributes["application_name"]    ||= attributes.delete("name")
       attributes["application_uris"]    ||= attributes.delete("uris")
@@ -186,7 +186,7 @@ module Dea
           "droplet_sha1"        => enum(nil, String),
           "droplet_uri"         => enum(nil, String),
 
-          optional("application_space_id") => String,
+          optional("tags")                 => dict(String, any),
           optional("runtime_name")         => String,
           optional("runtime_info")         => dict(String, any),
           optional("framework_name")       => String,

--- a/spec/unit/instance_spec.rb
+++ b/spec/unit/instance_spec.rb
@@ -70,12 +70,12 @@ describe Dea::Instance do
       let(:start_message_data) do
         {
             "droplet" => 37,
-            "space" => "af6c9790-08f7-429d-9528-4afbf07a3559",
+            "tags" => {"space" => "af6c9790-08f7-429d-9528-4afbf07a3559"},
         }
       end
 
       its(:application_id)      { should == "37" }
-      its(:application_space_id) { should == "af6c9790-08f7-429d-9528-4afbf07a3559" }
+      its(:tags) { should == {"space" => "af6c9790-08f7-429d-9528-4afbf07a3559" } }
     end
 
     describe "droplet attributes" do


### PR DESCRIPTION
- this is needed for log annotation
  - being handed the space_id is more efficent that looking it up downstream

Signed-off-by: Stephan Hagemann stephan@pivotallabs.com
