### PR TITLE
Fixed exception handling when parsing messages in the Nats

### DIFF
--- a/lib/dea/nats.rb
+++ b/lib/dea/nats.rb
@@ -74,8 +74,8 @@ module Dea
       sid = client.subscribe(subject, opts) do |raw_data, respond_to|
         begin
           yield handle_incoming_message(subject, raw_data, respond_to)
-        rescue => e
-          logger.error "Error \"#{e}\" raised while processing #{subject.inspect}: #{raw_data}"
+        rescue Yajl::ParseError => e
+          logger.error "Parse error \"#{e.message}\" raised while processing #{subject.inspect}: #{raw_data}"
         end
       end
 


### PR DESCRIPTION
This was rescuing all exceptions, which produced false positives in the specs.
