### PR TITLE
Add buildpack manager and hook for adding buildpacks in nats.rb

### DIFF
--- a/lib/dea/buildpack_manager.rb
+++ b/lib/dea/buildpack_manager.rb
@@ -1,0 +1,27 @@
+module Dea
+  class BuildpackManager
+    VENDOR_DIR = ""
+    def add_buildpack(message)
+      buildpack_name = message.data["name"]
+      return false if buildpack_name =~ %r|[\./]|
+
+      buildpack_url = message.data["url"]
+      buildpack_path = File.expand_path("../../../buildpacks/vendor/#{buildpack_name}", __FILE__)
+
+      return true if buildpack_exists?(buildpack_name)
+
+      system("git clone --recursive #{buildpack_url} #{buildpack_path}")
+    end
+
+    private
+
+    def buildpack_exists?(buildpack_name)
+      existing_buildpacks.include?(buildpack_name)
+    end
+
+    def existing_buildpacks
+      vendor_dir = File.expand_path("../../../buildpacks/vendor", __FILE__)
+      Dir.entries(vendor_dir).select {|entry| (entry !='.' && entry != '..') }
+    end
+  end
+end

--- a/lib/dea/nats.rb
+++ b/lib/dea/nats.rb
@@ -3,18 +3,18 @@
 require "steno"
 require "steno/core_ext"
 require "nats/client"
+require "dea/buildpack_manager"
 
 module Dea
   class Nats
-    attr_reader :bootstrap
-    attr_reader :config
-    attr_reader :sids
+    attr_reader :bootstrap, :config, :sids, :buildpack_manager
 
-    def initialize(bootstrap, config)
+    def initialize(bootstrap, config, buildpack_manager = BuildpackManager.new)
       @bootstrap = bootstrap
       @config    = config
       @sids      = {}
       @client    = nil
+      @buildpack_manager = buildpack_manager
     end
 
     def start
@@ -44,6 +44,14 @@ module Dea
 
       subscribe("dea.find.droplet") do |message|
         bootstrap.handle_dea_find_droplet(message)
+      end
+
+      subscribe("droplet.status") do |message|
+        bootstrap.handle_droplet_status(message)
+      end
+
+      subscribe("buildpacks.add") do |message|
+        buildpack_manager.add_buildpack(message)
       end
     end
 

--- a/spec/unit/buildpack_manager_spec.rb
+++ b/spec/unit/buildpack_manager_spec.rb
@@ -1,0 +1,51 @@
+# coding: UTF-8
+
+require "spec_helper"
+require "dea/buildpack_manager"
+require "dea/nats"
+
+describe Dea::BuildpackManager do
+  let(:manager) { Dea::BuildpackManager.new }
+
+  describe "#add_buildpack" do
+    it "clones the buildpack into the directory matching the given name" do
+      data = {
+          "name" => "liberty",
+          "url" => "git://example.com/foo/liberty-buildpack.git"
+      }
+      message = Dea::Nats::Message.new(nil, "buildpacks.add", data, "buildpacks.add.response")
+
+      expected_path = File.expand_path("../../../buildpacks/vendor/liberty", __FILE__)
+      manager.should_receive(:system).with(kind_of String) do |cmd|
+        expect(cmd).to eq("git clone --recursive git://example.com/foo/liberty-buildpack.git #{expected_path}")
+        true
+      end
+
+      expect(manager.add_buildpack(message)).to eq(true)
+    end
+
+    it "returns false if the name contains invalid characters . or /" do
+      data = {
+          "name" => "../../../liberty",
+          "url" => "git://example.com/foo/liberty-buildpack.git"
+      }
+      message = Dea::Nats::Message.new(nil, "buildpacks.add", data, "buildpacks.add.response")
+
+      manager.should_not_receive(:system)
+
+      expect(manager.add_buildpack(message)).to eq(false)
+    end
+
+    it "does nothing if the buildpack is already present" do
+      data = {
+          "name" => "java",
+          "url" => "git://example.com/foo/liberty-buildpack.git"
+      }
+      message = Dea::Nats::Message.new(nil, "buildpacks.add", data, "buildpacks.add.response")
+
+      manager.should_not_receive(:system)
+
+      expect(manager.add_buildpack(message)).to eq(true)
+    end
+  end
+end

--- a/spec/unit/nats_spec.rb
+++ b/spec/unit/nats_spec.rb
@@ -34,7 +34,20 @@ describe Dea::Nats do
         nats_mock.receive_message(subject, data)
       end
     end
+
+    it "subscribes to \"buildpacks.add\"" do
+      message_name = "buildpacks.add"
+      data = { "subject" => message_name}
+
+      nats.buildpack_manager.should_receive(:add_buildpack).with(kind_of(Dea::Nats::Message)) do |message|
+        message.subject.should == message_name
+        message.data.should == data
+      end
+
+      nats_mock.receive_message(message_name, data)
+    end
   end
+
 
   describe "subscription teardown" do
     it "should unsubscribe from everything when stop is called" do


### PR DESCRIPTION
This enables the dea to listen to messages on nats for adding buildpacks

This is related to the following pull request: https://github.com/cloudfoundry/cloud_controller_ng/pull/68
