### PR TITLE
Use FileUtils.cp_r instead of system cp.

### DIFF
--- a/buildpacks/lib/buildpack.rb
+++ b/buildpacks/lib/buildpack.rb
@@ -69,7 +69,8 @@ module Buildpacks
     end
 
     def copy_source_files
-      system "cp -a #{File.join(source_directory, ".")} #{app_dir}"
+      src_dir = File.join(source_directory, '.')
+      FileUtils.cp_r(src_dir, app_dir)
       FileUtils.chmod_R(0744, app_dir)
     end
 


### PR DESCRIPTION
Hello -

While doing some updates on the Iron Foundry fork of `dea_ng`, I found that a call out to the system `cp` command had been added, which doesn't work on Windows. This change will use the `FileUtils` method instead, which is cross-platform.

Is there an advantage to using the `cp` command in this case? Thanks!
