### PR TITLE
Allow branches or tags to be specified as a fragment on the build pack url

### DIFF
--- a/buildpacks/lib/buildpack.rb
+++ b/buildpacks/lib/buildpack.rb
@@ -126,7 +126,7 @@ module Buildpacks
       if !ok
         ok = system("git clone --recursive #{buildpack_url} #{buildpack_path}")
         raise "Failed to git clone buildpack" unless ok
-        ok = system("git checkout #{git_branch_tag}")
+        ok = system("git --git-dir=#{buildpack_path}/.git --work-tree=#{buildpack_path} checkout #{git_branch_tag}")
         raise "Failed to git checkout buildpack" unless ok
       end
       Buildpacks::Installer.new(Pathname.new(buildpack_path), app_dir, cache_dir)

--- a/spec/unit/buildpack/buildpack_spec.rb
+++ b/spec/unit/buildpack/buildpack_spec.rb
@@ -295,7 +295,7 @@ fi
           true
         end
         build_pack.should_receive(:system) do |cmd|
-          expect(cmd).to eq("git checkout #{branch}")
+          expect(cmd).to eq("git --git-dir=/tmp/buildpacks/heroku-buildpack-java.git/.git --work-tree=/tmp/buildpacks/heroku-buildpack-java.git checkout 49f320c5f8178279dd58af6de5ad525b72cc79d2")
           true
         end
         


### PR DESCRIPTION
This modification does not support SHAs.
With the use of --depth 1, certain tags are not supported.
If the branch/tag provided does not exist, git will pull from HEAD
