### PR TITLE
Remove the tag hash with org and space from the start app message

### DIFF
--- a/lib/dea/instance.rb
+++ b/lib/dea/instance.rb
@@ -115,7 +115,6 @@ module Dea
       transfer_attr_with_existance_check(attributes, "application_uris", "uris")
 
       attributes["application_id"] ||= attributes.delete("droplet").to_s if attributes["droplet"]
-      attributes["tags"] ||= attributes.delete("tags") { |_| {} } if attributes["tags"]
       attributes["droplet_sha1"] ||= attributes.delete("sha1")
       attributes["droplet_uri"] ||= attributes.delete("executableUri")
 
@@ -183,7 +182,6 @@ module Dea
           "droplet_sha1"        => enum(nil, String),
           "droplet_uri"         => enum(nil, String),
 
-          optional("tags")                 => dict(String, any),
           optional("runtime_name")         => String,
           optional("runtime_info")         => dict(String, any),
           optional("framework_name")       => String,

--- a/spec/unit/instance_spec.rb
+++ b/spec/unit/instance_spec.rb
@@ -73,20 +73,11 @@ describe Dea::Instance do
     describe "instance data from message data" do
       let(:start_message_data) do
         {
-          "droplet" => 37,
-          "tags" => {
-                "any_tag" => "any value"
-            },
+          "droplet" => 37
         }
       end
 
       its(:application_id) { should == "37" }
-
-      it "sets all tags from the message" do
-        expect(subject.tags).to eql(
-          "any_tag" => "any value"
-        )
-      end
     end
 
     describe "droplet attributes" do


### PR DESCRIPTION
Remove the tag hash that contains the org and space from the start app message, since loggregator does not need the space and org anymore

Signed-off-by: Johannes Tuchscherer jtuchscherer@pivotallabs.com
