### PR TITLE
Support buildpack URLs with git revision

### DIFF
--- a/buildpacks/lib/buildpack.rb
+++ b/buildpacks/lib/buildpack.rb
@@ -114,9 +114,14 @@ module Buildpacks
     end
 
     def clone_buildpack(buildpack_url)
+      (buildpack_url, revision) = buildpack_url.split('#')
       buildpack_path = "/tmp/buildpacks/#{File.basename(buildpack_url)}"
       ok = system("git clone --recursive #{buildpack_url} #{buildpack_path}")
       raise "Failed to git clone buildpack" unless ok
+      unless revision.nil?
+        ok = system("cd #{buildpack_path} && git checkout --quiet #{revision}")
+        raise "Failed to git checkout revision '#{revision}'" unless ok
+      end
       Buildpacks::Installer.new(Pathname.new(buildpack_path), app_dir, cache_dir)
     end
 


### PR DESCRIPTION
Heroku lets you append a git revision to the end of a
buildpack URL (separated by '#'), like this:

--buildpack http://github.com/heroku/heroku-buildpack-java.git#debug

This commit implements the same functionality for CF.

PR made under ActiveState CLA.
