### PR TITLE
Updated gem dependencies to use proper timestamps in loggregator messsages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,8 @@ gem "uuidtools", "~> 2.1.2"
 gem "nokogiri", ">= 1.4.4"
 gem "vmstat"
 
-gem "loggregator_emitter", "~> 0.0.9.pre"
-gem "loggregator_messages", "~> 0.0.3.pre"
+gem "loggregator_emitter", "~> 0.0.11.pre"
+gem "loggregator_messages", "~> 0.0.5.pre"
 
 gem "sys-filesystem"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,9 +126,9 @@ GEM
       chef (>= 0.10)
       highline
       thor (~> 0.15)
-    loggregator_emitter (0.0.9.pre)
+    loggregator_emitter (0.0.11.pre)
       loggregator_messages (~> 0.0.1.pre)
-    loggregator_messages (0.0.3.pre)
+    loggregator_messages (0.0.5.pre)
       beefcake (~> 0.3.7)
     membrane (0.0.2)
     mime-types (1.23)
@@ -219,8 +219,8 @@ DEPENDENCIES
   foreman
   grape!
   librarian
-  loggregator_emitter (~> 0.0.9.pre)
-  loggregator_messages (~> 0.0.3.pre)
+  loggregator_emitter (~> 0.0.11.pre)
+  loggregator_messages (~> 0.0.5.pre)
   nats
   nokogiri (>= 1.4.4)
   patron


### PR DESCRIPTION
This updates the required gem versions for loggregator_emitter and loggregator_messages to emit the correct timestamps.
