### PR TITLE
Update the Loggregator Emitter gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "uuidtools", "~> 2.1.2"
 gem "nokogiri", ">= 1.4.4"
 gem "vmstat"
 
-gem "loggregator_emitter", "~> 0.0.13.pre"
+gem "loggregator_emitter", "~> 0.0.15.pre"
 
 gem "sys-filesystem"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       chef (>= 0.10)
       highline
       thor (~> 0.15)
-    loggregator_emitter (0.0.13.pre)
+    loggregator_emitter (0.0.15.pre)
       beefcake (~> 0.3.7)
     membrane (0.0.2)
     mime-types (1.23)
@@ -224,7 +224,7 @@ DEPENDENCIES
   foreman
   grape!
   librarian
-  loggregator_emitter (~> 0.0.13.pre)
+  loggregator_emitter (~> 0.0.15.pre)
   nats
   net-ssh
   nokogiri (>= 1.4.4)


### PR DESCRIPTION
This update uses the loggregator_emitter gem that has inlined loggregator_messages.

@matthewmcnew / @caseymct
