### PR TITLE
emit staging output to loggregator

### DIFF
--- a/lib/dea/staging/staging_task.rb
+++ b/lib/dea/staging/staging_task.rb
@@ -11,6 +11,7 @@ require "dea/env"
 require "dea/staging/admin_buildpack_downloader"
 require "dea/staging/staging_task_workspace"
 require "dea/staging/staging_message"
+require "dea/loggregator"
 
 module Dea
   class StagingTask < Task
@@ -204,13 +205,13 @@ module Dea
           config["dea_ruby"],
           run_plugin_path,
           workspace.plugin_config_path,
-          ">> #{workspace.warden_staging_log} 2>&1"
+          "| tee -a #{workspace.warden_staging_log}"
         ].join(" ")
 
         logger.debug "staging.task.execute-staging", script: script
 
         Timeout.timeout(staging_timeout + staging_timeout_grace_period) do
-          container.run_script(:app, script)
+          loggregator_emit_result container.run_script(:app, script)
         end
 
         p.deliver
@@ -237,9 +238,9 @@ module Dea
       Promise.new do |p|
         logger.info "staging.task.unpacking-app", destination: workspace.warden_unstaged_dir
 
-        container.run_script(:app, <<-BASH)
+        loggregator_emit_result container.run_script(:app, <<-BASH)
           package_size=`du -h #{workspace.downloaded_app_package_path} | cut -f1`
-          echo "-----> Downloaded app package ($package_size)" >> #{workspace.warden_staging_log}
+          echo "-----> Downloaded app package ($package_size)" | tee -a #{workspace.warden_staging_log}
           unzip -q #{workspace.downloaded_app_package_path} -d #{workspace.warden_unstaged_dir}
         BASH
 
@@ -289,9 +290,9 @@ module Dea
 
     def promise_log_upload_started
       Promise.new do |p|
-        container.run_script(:app, <<-BASH)
+        loggregator_emit_result container.run_script(:app, <<-BASH)
           droplet_size=`du -h #{workspace.warden_staged_droplet} | cut -f1`
-          echo "-----> Uploading droplet ($droplet_size)" >> #{workspace.warden_staging_log}
+          echo "-----> Uploading droplet ($droplet_size)" | tee -a #{workspace.warden_staging_log}
         BASH
         p.deliver
       end
@@ -445,9 +446,9 @@ module Dea
           logger.info "staging.buildpack-cache.unpack",
             destination: workspace.warden_cache
 
-          container.run_script(:app, <<-BASH)
+          loggregator_emit_result container.run_script(:app, <<-BASH)
           package_size=`du -h #{workspace.downloaded_buildpack_cache_path} | cut -f1`
-          echo "-----> Downloaded app buildpack cache ($package_size)" >> #{workspace.warden_staging_log}
+          echo "-----> Downloaded app buildpack cache ($package_size)" | tee -a #{workspace.warden_staging_log}
           mkdir -p #{workspace.warden_cache}
           tar xfz #{workspace.downloaded_buildpack_cache_path} -C #{workspace.warden_cache}
           BASH
@@ -543,6 +544,14 @@ module Dea
 
     def staging_timeout_grace_period
       60
+    end
+
+    def loggregator_emit_result(result)
+      if (result != nil)
+        Dea::Loggregator.emit(staging_message.app_id, result.stdout)
+        Dea::Loggregator.emit_error(staging_message.app_id, result.stderr)
+      end
+      result
     end
   end
 end

--- a/spec/unit/staging/staging_task_spec.rb
+++ b/spec/unit/staging/staging_task_spec.rb
@@ -8,6 +8,11 @@ require "dea/directory_server/directory_server_v2"
 require "dea/staging/staging_task"
 
 describe Dea::StagingTask do
+  before(:all) do
+    @emitter = FakeEmitter.new
+    Dea::Loggregator.emitter = @emitter
+  end
+
   let(:memory_limit_mb) { 256 }
   let(:disk_limit_mb) { 1025 }
 
@@ -54,6 +59,8 @@ describe Dea::StagingTask do
 
   let(:failing_promise) { Dea::Promise.new { |p| raise "failing promise" } }
 
+  let (:empty_streams) { double(:stdout => '', :stderr => '') }
+
   subject(:staging) { Dea::StagingTask.new(bootstrap, dir_server, StagingMessage.new(attributes), buildpacks_in_use) }
 
   after { FileUtils.rm_rf(workspace_dir) if File.exists?(workspace_dir) }
@@ -76,8 +83,19 @@ describe Dea::StagingTask do
         expect(cmd).to include %Q{export VCAP_SERVICES="}
 
         expect(cmd).to match %r{.*/bin/run .*/plugin_config >> /tmp/staged/logs/staging_task.log 2>&1$}
-      end
+      end.and_return(empty_streams)
       staging.promise_stage.resolve
+    end
+
+    it "logs to the loggregator" do
+      @emitter.reset
+      staging.container.should_receive(:run_script).and_return(double(:stdout => "stdout message", :stderr => "stderr message"))
+      staging.promise_stage.resolve
+      app_id = staging.staging_message.app_id
+      expect(@emitter.messages.size).to eql(1)
+      expect(@emitter.error_messages.size).to eql(1)
+      expect(@emitter.messages[app_id][0]).to eql("stdout message")
+      expect(@emitter.error_messages[app_id][0]).to eql("stderr message")
     end
 
     context "when env variables need to be escaped" do
@@ -86,28 +104,28 @@ describe Dea::StagingTask do
       it "copes with spaces" do
         staging.container.should_receive(:run_script) do |_, cmd|
           expect(cmd).to include(%Q{export PATH="x y z";})
-        end
+        end.and_return(empty_streams)
         staging.promise_stage.resolve
       end
 
       it "copes with quotes" do
         staging.container.should_receive(:run_script) do |_, cmd|
           expect(cmd).to include(%Q{export FOO="z'y\\"d";})
-        end
+        end.and_return(empty_streams)
         staging.promise_stage.resolve
       end
 
       it "copes with blank" do
         staging.container.should_receive(:run_script) do |_, cmd|
           expect(cmd).to include(%Q{export BAR="";})
-        end
+        end.and_return(empty_streams)
         staging.promise_stage.resolve
       end
 
       it "copes with equal sign" do
         staging.container.should_receive(:run_script) do |_, cmd|
           expect(cmd).to include(%Q{export BAZ="foo=baz";})
-        end
+        end.and_return(empty_streams)
         staging.promise_stage.resolve
       end
     end
@@ -133,7 +151,7 @@ describe Dea::StagingTask do
 
           staging.container.should_receive(:run_script) do
             sleep 0.75
-          end
+          end.and_return(empty_streams)
 
           expect { staging.promise_stage.resolve }.to_not raise_error
         end
@@ -747,9 +765,18 @@ YAML
     it "assembles a shell command" do
       staging.container.should_receive(:run_script) do |connection_name, cmd|
         cmd.should include("unzip -q #{workspace_dir}/app.zip -d /tmp/unstaged")
-      end
-
+      end.and_return(empty_streams)
       staging.promise_unpack_app.resolve
+    end
+
+    it "logs to loggregator" do
+      staging.container.should_receive(:run_script).and_return(double(:stdout => "stdout message", :stderr => "stderr message"))
+      staging.promise_unpack_app.resolve
+      app_id = staging.staging_message.app_id
+      expect(@emitter.messages.size).to eql(1)
+      expect(@emitter.error_messages.size).to eql(1)
+      expect(@emitter.messages[app_id][0]).to eql("stdout message")
+      expect(@emitter.error_messages[app_id][0]).to eql("stderr message")
     end
   end
 
@@ -769,9 +796,18 @@ YAML
       it "assembles a shell command" do
         staging.container.should_receive(:run_script) do |_, cmd|
           cmd.should include("tar xfz #{workspace_dir}/buildpack_cache.tgz -C /tmp/cache")
-        end
-
+        end.and_return(empty_streams)
         staging.promise_unpack_buildpack_cache.resolve
+      end
+
+      it "logs to loggregator" do
+        staging.container.should_receive(:run_script).and_return(double(:stdout => "stdout message", :stderr => "stderr message"))
+        staging.promise_unpack_buildpack_cache.resolve
+        app_id = staging.staging_message.app_id
+        expect(@emitter.messages.size).to eql(1)
+        expect(@emitter.error_messages.size).to eql(1)
+        expect(@emitter.messages[app_id][0]).to eql("stdout message")
+        expect(@emitter.error_messages[app_id][0]).to eql("stderr message")
       end
     end
   end


### PR DESCRIPTION
This emits the staging output directly to loggregator.   Since we are using the "run_script" feature of warden in the dea, we can't use the same approach we took for application logs.  (listening to the unix sockets for stdout/err)  This is because the "run_script" command is synchronous.

[finishes #51986963]
