### PR TITLE
Bump loggregator_emitter to version 1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "uuidtools", "~> 2.1.2"
 gem "nokogiri", ">= 1.4.4"
 gem "vmstat"
 
-gem "loggregator_emitter", "~> 0.0.16"
+gem "loggregator_emitter", "~> 1.0"
 
 gem "sys-filesystem"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       chef (>= 0.10)
       highline
       thor (~> 0.15)
-    loggregator_emitter (0.0.16)
+    loggregator_emitter (1.0.0)
       beefcake (~> 0.3.7)
     membrane (0.0.2)
     mime-types (1.23)
@@ -224,7 +224,7 @@ DEPENDENCIES
   foreman
   grape!
   librarian
-  loggregator_emitter (~> 0.0.16)
+  loggregator_emitter (~> 1.0)
   nats
   net-ssh
   nokogiri (>= 1.4.4)


### PR DESCRIPTION
This bump adds a security mechanism where the emitter will not emit empty log messages. It also allows for loggregator to be a log source type.

Signed-off-by: Casey McTaggart cmctaggart@pivotallabs.com
