### PR TITLE
app startup timeout is now configurable in dea.yml

### DIFF
--- a/config/dea.yml
+++ b/config/dea.yml
@@ -23,6 +23,8 @@ warden_socket: /tmp/warden.sock
 
 evacuation_delay_secs: 10
 
+maximum_health_check_timeout: 60 # 1 minute
+
 index: 0
 domain: "localhost.xip.io"
 

--- a/lib/dea/config.rb
+++ b/lib/dea/config.rb
@@ -46,6 +46,8 @@ module Dea
 
           optional("evacuation_delay_secs") => Integer,
 
+          optional("maximum_health_check_timeout") => Integer,
+
           optional("status") => {
             optional("user")     => String,
             optional("port")     => Integer,

--- a/lib/dea/starting/instance.rb
+++ b/lib/dea/starting/instance.rb
@@ -709,7 +709,7 @@ module Dea
 
           hc.errback  { p.deliver(false) }
 
-          hc.timeout(60)
+          hc.timeout(max_healthcheck_timeout)
         end
       end
     end
@@ -870,6 +870,10 @@ module Dea
 
       # New path
       File.join(root, "tmp", "rootfs", "home", "vcap", *parts)
+    end
+
+    def max_healthcheck_timeout
+      config["maximum_health_check_timeout"] || 60
     end
 
     def logger

--- a/spec/unit/starting/instance_spec.rb
+++ b/spec/unit/starting/instance_spec.rb
@@ -433,8 +433,16 @@ describe Dea::Instance do
         Dea::HealthCheck::PortOpen.stub(:new).and_yield(deferrable)
       end
 
-      it "sets a timeout of 60 seconds" do
+      it "defaults to 60 seconds timeout" do
         deferrable.should_receive(:timeout).with(60)
+        execute_health_check do
+          deferrable.succeed
+        end
+      end
+
+      it "has a configurable timeout" do
+        bootstrap.config["maximum_health_check_timeout"] = 100
+        deferrable.should_receive(:timeout).with(100)
         execute_health_check do
           deferrable.succeed
         end


### PR DESCRIPTION
App healthcheck timeout is now hardcoded at 60sec, some of the apps take a long time to start after being pushed.  This change allows  timeout value to be configurable in dea.yml.

*\* Potential to do:
to further enhance this, the user could configure each app's timeout while pushing, by sending in an extra field in manifest file included in the app bits, anyone have ideas about the best way to support this?
