### PR TITLE
Expose available_disk in advertisement message.

### DIFF
--- a/lib/dea/protocol.rb
+++ b/lib/dea/protocol.rb
@@ -76,6 +76,7 @@ module Dea::Protocol::V1
       { "id" => message[:id],
         "stacks" => message[:stacks],
         "available_memory" => message[:available_memory],
+        "available_disk" => message[:available_disk],
         "app_id_to_count" => message[:app_id_to_count],
       }
     end

--- a/lib/dea/responders/dea_locator.rb
+++ b/lib/dea/responders/dea_locator.rb
@@ -33,6 +33,7 @@ module Dea::Responders
           :id => dea_id,
           :stacks => config["stacks"] || [],
           :available_memory => resource_manager.remaining_memory,
+          :available_disk => resource_manager.remaining_disk,
           :app_id_to_count => resource_manager.app_id_to_count,
         }),
       )


### PR DESCRIPTION
Cloud Controller currently assumes that if a DEA has enough memory, it
has enough disk. This is not always true (especially if an app requires
a large disk_quota). This commit adds the available_disk to the message
so that Cloud Controller can use this information to check if a DEA has
space before attempting to start the app.

We had problems starting apps when a DEA which had enough memory but
had run out of reservable disk space would often get chosen to start an app and
immediately fail when it attempted to reserve the resources.
