### PR TITLE
allow health check timeout to be configurabled through app attributes

### DIFF
--- a/config/dea.yml
+++ b/config/dea.yml
@@ -23,7 +23,7 @@ warden_socket: /tmp/warden.sock
 
 evacuation_delay_secs: 10
 
-maximum_health_check_timeout: 60 # 1 minute
+health_check_timeout_seconds: 60 # 1 minute
 
 index: 0
 domain: "localhost.xip.io"

--- a/lib/dea/starting/instance.rb
+++ b/lib/dea/starting/instance.rb
@@ -709,7 +709,7 @@ module Dea
 
           hc.errback  { p.deliver(false) }
 
-          hc.timeout(health_check_timeout)
+          hc.timeout(health_check_timeout_seconds)
         end
       end
     end
@@ -872,16 +872,16 @@ module Dea
       File.join(root, "tmp", "rootfs", "home", "vcap", *parts)
     end
 
-    def health_check_timeout
-      app_specific_health_check_timeout || global_default_health_check_timeout || 60
+    def health_check_timeout_seconds
+      app_specific_health_check_timeout_seconds || global_default_health_check_timeout_seconds || 60
     end
 
-    def app_specific_health_check_timeout
-      attributes["health_check_timeout"]
+    def app_specific_health_check_timeout_seconds
+      attributes["health_check_timeout_seconds"]
     end
 
-    def global_default_health_check_timeout
-      config["maximum_health_check_timeout"]
+    def global_default_health_check_timeout_seconds
+      config["health_check_timeout_seconds"]
     end
 
     def logger

--- a/spec/unit/starting/instance_spec.rb
+++ b/spec/unit/starting/instance_spec.rb
@@ -441,7 +441,7 @@ describe Dea::Instance do
       end
 
       it "has a configurable timeout" do
-        bootstrap.config["maximum_health_check_timeout"] = 100
+        bootstrap.config["health_check_timeout_seconds"] = 100
         deferrable.should_receive(:timeout).with(100)
         execute_health_check do
           deferrable.succeed
@@ -449,8 +449,8 @@ describe Dea::Instance do
       end
 
       it "can override yml global timeout value with value from app attribute" do
-        bootstrap.config["maximum_health_check_timeout"] = 100
-        instance.attributes["health_check_timeout"] = 200
+        bootstrap.config["health_check_timeout_seconds"] = 100
+        instance.attributes["health_check_timeout_seconds"] = 200
         deferrable.should_receive(:timeout).with(200)
         execute_health_check do
           deferrable.succeed


### PR DESCRIPTION
The health check timeout is currently configurable only through dea.yml, the config value applies to all pushed apps, and there isn't any way for individual app to configure it's timeout value.

With this change, individual app can configure the timeout value through an app attribute, this will override the value in dea.yml and the default value (60 sec).

This commit relies on "new field in api endpoint to allow configurable health check timeout" (see <a href='https://github.com/cloudfoundry/cloud_controller_ng/pull/123'>cloudfoundry/cloud_controller_ng#123</a>)
