### PR TITLE
This changeset adds support of max_instances and available_instances.  

### DIFF
--- a/config/dea.yml
+++ b/config/dea.yml
@@ -15,6 +15,7 @@ resources:
   memory_overcommit_factor: 2
   disk_mb: 2048
   disk_overcommit_factor: 2
+  max_instances: 256
 
 nats_servers:
   - nats://localhost:4222/

--- a/lib/dea/config.rb
+++ b/lib/dea/config.rb
@@ -80,6 +80,8 @@ module Dea
 
             optional("disk_mb") => Integer,
             optional("disk_overcommit_factor") => enum(Float, Integer),
+
+            optional("max_instances") => Integer,
           },
 
           optional("bind_mounts") => [{

--- a/lib/dea/protocol.rb
+++ b/lib/dea/protocol.rb
@@ -75,6 +75,7 @@ module Dea::Protocol::V1
         "stacks" => message[:stacks],
         "available_memory" => message[:available_memory],
         "available_disk" => message[:available_disk],
+        "available_instances" => message[:available_instances],
         "app_id_to_count" => message[:app_id_to_count],
         "placement_properties" => {"zone" => message[:placement_zone]},
       }

--- a/lib/dea/responders/dea_locator.rb
+++ b/lib/dea/responders/dea_locator.rb
@@ -34,6 +34,7 @@ module Dea::Responders
           stacks: config["stacks"] || [],
           available_memory: resource_manager.remaining_memory,
           available_disk: resource_manager.remaining_disk,
+          available_instances: resource_manager.remaining_instances,
           app_id_to_count: resource_manager.app_id_to_count,
           placement_zone: config["placement_properties"]["zone"]
         ),

--- a/lib/dea/starting/instance_registry.rb
+++ b/lib/dea/starting/instance_registry.rb
@@ -87,6 +87,10 @@ module Dea
       app_count
     end
 
+    def undeleted_instances_count
+      @instances.size  - select(&:deleted?).size
+    end
+
     def each(&block)
       @instances.each_value(&block)
     end

--- a/spec/unit/responders/dea_locator_spec.rb
+++ b/spec/unit/responders/dea_locator_spec.rb
@@ -101,6 +101,7 @@ describe Dea::Responders::DeaLocator do
     let(:config_overrides) { { "stacks" => ["stack-1", "stack-2"] } }
     let(:available_disk) { 12345 }
     let(:available_memory) { 45678 }
+    let(:available_instances) { 1 }
     before do
       resource_manager.stub(app_id_to_count: {
         "app_id_1" => 1,
@@ -108,6 +109,7 @@ describe Dea::Responders::DeaLocator do
       })
       resource_manager.stub(:remaining_memory => available_memory)
       resource_manager.stub(:remaining_disk => available_disk)
+      resource_manager.stub(:remaining_instances => available_instances)
     end
 
     it "publishes 'dea.advertise' message" do
@@ -117,6 +119,7 @@ describe Dea::Responders::DeaLocator do
           "stacks" => ["stack-1", "stack-2"],
           "available_memory" => available_memory,
           "available_disk" => available_disk,
+          "available_instances" => available_instances,
           "app_id_to_count" => {
             "app_id_1" => 1,
             "app_id_2" => 3

--- a/spec/unit/starting/instance_registry_spec.rb
+++ b/spec/unit/starting/instance_registry_spec.rb
@@ -18,6 +18,7 @@ describe Dea::InstanceRegistry do
   let(:instance) { Dea::Instance.new(bootstrap, {"application_id" => 1, "warden_handle" => "handle1", "index" => 0}) }
 
   let(:instance1) { Dea::Instance.new(bootstrap, {"application_id" => 1, "warden_handle" => "handle2"}) }
+  let(:instance2) { Dea::Instance.new(bootstrap, "application_id" => "g").tap { |i| i.state = "DELETED" }}
 
   it_behaves_like :handles_registry_enumerations
 
@@ -90,6 +91,76 @@ describe Dea::InstanceRegistry do
 
       expect(emitter.messages[1][0]).to eql("Stopping app instance (index 0) with guid 1")
       expect(emitter.messages[1][1]).to eql("Stopped app instance (index 0) with guid 1")
+    end
+  end
+
+  describe "#undeleted_instances_count" do
+    before :each do
+      instance_registry.register(instance)
+      instance_registry.register(instance1)
+    end
+
+    context "when no instance is deleted" do
+      it "should return total number of instances which is two" do
+        instance_registry.undeleted_instances_count.should  eql(2)
+      end
+    end
+
+    context "when a regular instance is unregistered" do
+      it "should decrement total number of instances by one" do
+        instance_registry.unregister(instance)
+        expect(instance_registry.undeleted_instances_count).to eql(1)
+      end
+    end
+
+    context "when an instance with DELETED state is registered" do
+      it "should have total number of instances unchanged" do
+        instance_registry.register(instance2)
+        expect(instance_registry.undeleted_instances_count).to eql(2)
+      end
+    end
+
+    context "when an instance with DELETED state is registered and a regular instance is unregistered" do
+      it "should decrement total number of instances by one" do
+        instance_registry.register(instance2)
+        instance_registry.unregister(instance)
+        expect(instance_registry.undeleted_instances_count).to eql(1)
+      end
+    end
+  end
+
+  describe "#undeleted_instances_count" do
+    before :each do
+      instance_registry.register(instance)
+      instance_registry.register(instance1)
+    end
+
+    context "when no instance is deleted" do
+      it "should return total number of instances which is two" do
+        instance_registry.undeleted_instances_count.should  eql(2)
+      end
+    end
+
+    context "when a regular instance is unregistered" do
+      it "should decrement total number of instances by one" do
+        instance_registry.unregister(instance)
+        expect(instance_registry.undeleted_instances_count).to eql(1)
+      end
+    end
+
+    context "when an instance with DELETED state is registered" do
+      it "should have total number of instances unchanged" do
+        instance_registry.register(instance2)
+        expect(instance_registry.undeleted_instances_count).to eql(2)
+      end
+    end
+
+    context "when an instance with DELETED state is registered and a regular instance is unregistered" do
+      it "should decrement total number of instances by one" do
+        instance_registry.register(instance2) 
+        instance_registry.unregister(instance)
+        expect(instance_registry.undeleted_instances_count).to eql(1)
+      end
     end
   end
 


### PR DESCRIPTION
Resource manager tracks all registered instances, except those in the DELETED state.  Its could_reserve? and numbers reserverable methods responds positively when the total number of undeleted instances fall under the max_instances limit.
