### PR TITLE
Ensure %CPU is available when disk quota disabled

### DIFF
--- a/lib/dea/stat_collector.rb
+++ b/lib/dea/stat_collector.rb
@@ -30,7 +30,7 @@ module Dea
         :error => e, :backtrace => e.backtrace
     else
       @used_memory_in_bytes = info.memory_stat.rss * 1024
-      @used_disk_in_bytes = info.disk_stat.bytes_used
+      @used_disk_in_bytes = info.disk_stat.bytes_used if info.disk_stat
       compute_cpu_usage(info.cpu_stat.usage, now)
     end
 


### PR DESCRIPTION
The stat_collector task was coded with the expectation that disk statistics would always be available but, when disk quotas are disabled for warden, the [statistics are not populated](https://github.com/cloudfoundry/warden/blob/master/warden/lib/warden/container/features/quota.rb#L105).  When disk_stat is nil, the collector takes an exception dereferencing the message and that exception prevents the cpu statistics management code from executing.  The result is the dea reporting 0% CPU consumption for the droplet container.

This adds a check for nil on the disk usage assignment.
