### PR TITLE
Consistently use bytes for memory statistics

### DIFF
--- a/lib/dea/protocol.rb
+++ b/lib/dea/protocol.rb
@@ -57,7 +57,7 @@ module Dea::Protocol::V1
           "usage"      => {
             "time" => Time.now.to_s,
             "cpu"  => instance.computed_pcpu,
-            "mem"  => instance.used_memory_in_bytes / 1024,
+            "mem"  => instance.used_memory_in_bytes,
             "disk" => instance.used_disk_in_bytes,
           },
           # Purposefully omitted, as I'm not sure what purpose it serves.

--- a/lib/dea/starting/instance.rb
+++ b/lib/dea/starting/instance.rb
@@ -768,7 +768,7 @@ module Dea
 
     def attributes_and_stats
       @attributes.merge({
-          "used_memory_in_bytes" => used_memory_in_bytes / 1024,
+          "used_memory_in_bytes" => used_memory_in_bytes,
           "used_disk_in_bytes" => used_disk_in_bytes,
           "computed_pcpu" => computed_pcpu
       })

--- a/lib/dea/stat_collector.rb
+++ b/lib/dea/stat_collector.rb
@@ -29,7 +29,7 @@ module Dea
         :handle => @container.handle,
         :error => e, :backtrace => e.backtrace
     else
-      @used_memory_in_bytes = info.memory_stat.rss * 1024
+      @used_memory_in_bytes = info.memory_stat.rss
       @used_disk_in_bytes = info.disk_stat.bytes_used if info.disk_stat
       compute_cpu_usage(info.cpu_stat.usage, now)
     end

--- a/spec/unit/bootstrap_spec.rb
+++ b/spec/unit/bootstrap_spec.rb
@@ -318,7 +318,7 @@ describe Dea::Bootstrap do
         end
 
         it "uses the values from stat_collector" do
-          instance_1.stat_collector.stub(:used_memory_in_bytes).and_return(28 * 1024)
+          instance_1.stat_collector.stub(:used_memory_in_bytes).and_return(999)
           instance_1.stat_collector.stub(:used_disk_in_bytes).and_return(40)
           instance_1.stat_collector.stub(:computed_pcpu).and_return(0.123)
 
@@ -328,7 +328,7 @@ describe Dea::Bootstrap do
 
           varz.keys.should == ["app-1"]
           varz["app-1"][instance_1.instance_id].should include(
-            "used_memory_in_bytes" => 28,
+            "used_memory_in_bytes" => 999,
             "used_disk_in_bytes" => 40,
             "computed_pcpu" => 0.123
           )

--- a/spec/unit/starting/instance_spec.rb
+++ b/spec/unit/starting/instance_spec.rb
@@ -304,8 +304,8 @@ describe Dea::Instance do
 
   describe "attributes_and_stats from stat collector" do
     it "returns the used_memory_in_bytes stat in the attributes_and_stats hash" do
-      instance.stat_collector.stub(:used_memory_in_bytes).and_return(28 * 1024)
-      instance.attributes_and_stats.should include("used_memory_in_bytes" => 28)
+      instance.stat_collector.stub(:used_memory_in_bytes).and_return(999)
+      instance.attributes_and_stats.should include("used_memory_in_bytes" => 999)
     end
 
     it "returns the used_disk_in_bytes stat in the attributes_and_stats hash" do

--- a/spec/unit/stat_collector_spec.rb
+++ b/spec/unit/stat_collector_spec.rb
@@ -116,7 +116,7 @@ describe Dea::StatCollector do
 
       before { collector.retrieve_stats(Time.now) }
 
-      its(:used_memory_in_bytes) { should eq(2 * 1024) }
+      its(:used_memory_in_bytes) { should eq(2) }
       its(:used_disk_in_bytes) { should eq(42) }
       its(:computed_pcpu) { should eq(0) }
     end


### PR DESCRIPTION
For some reason, stat_collector assumed rss was reported in kilobytes
instead of bytes and multiplied it by 1024.  The rest of the code then
started to divide the 'used_memory_in_bytes' by 1024 to really get bytes
back.  Very odd.

This change simply removes the hacks that multiply and divide to get
expected data.
