### PR TITLE
Emit staging messages even when staging fails

### DIFF
--- a/lib/dea/staging/staging_task.rb
+++ b/lib/dea/staging/staging_task.rb
@@ -204,11 +204,17 @@ module Dea
 
         logger.debug "staging.task.execute-staging", script: script
 
-        Timeout.timeout(staging_timeout + staging_timeout_grace_period) do
-          loggregator_emit_result container.run_script(:app, script)
+        begin
+          Timeout.timeout(staging_timeout + staging_timeout_grace_period) do
+            loggregator_emit_result container.run_script(:app, script)
+          end
+          p.deliver
+        rescue Container::WardenError => staging_error
+          loggregator_emit_result(staging_error.result)
+          p.fail(staging_error)
+        rescue Timeout::Error => timeout_error
+          p.fail(timeout_error)
         end
-
-        p.deliver
       end
     end
 


### PR DESCRIPTION
Prior to loggregator, staging output was provided to the user by tailing the logs generated during staging.  This pattern enabled end users to see messages generated while staging was in-flight and included messages related to failures in staging, but the newer Loggregator paths only emit staging messages when staging completes successfully.

This change will cause staging messages to be emitted even when staging fails but it still requires the staging task to complete.

For what it's worth, I believe the _right_ way to do this is to stream the log data as staging is running. I'll be looking into that but the lack of any diagnostics from a failed staging attempt is painful so this is an interim step.

Note: This depends on a change to container_tools to preserve the result of failed staging.
