### PR TITLE
Bump loggregator_emitter gem to 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "uuidtools", "~> 2.1.2"
 gem "nokogiri", ">= 1.4.4"
 gem "vmstat"
 
-gem "loggregator_emitter", "~> 2.0"
+gem "loggregator_emitter", "~> 3.0"
 
 gem "sys-filesystem"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       chef (>= 0.10)
       highline
       thor (~> 0.15)
-    loggregator_emitter (2.0.3)
+    loggregator_emitter (3.0.0)
       beefcake (~> 0.3.7)
     membrane (0.0.2)
     mime-types (1.23)
@@ -230,7 +230,7 @@ DEPENDENCIES
   foreman
   grape!
   librarian
-  loggregator_emitter (~> 2.0)
+  loggregator_emitter (~> 3.0)
   nats (>= 0.5.0.beta.12, < 0.6)
   net-ssh
   nokogiri (>= 1.4.4)


### PR DESCRIPTION
This Removes the Source Type from the LogMessages. 

Signed-off-by: John Tuley jtuley@pivotallabs.com
