### PR TITLE
Provide config option for DEA to disable droplet cache

### DIFF
--- a/config/dea.yml
+++ b/config/dea.yml
@@ -66,3 +66,5 @@ stacks:
 
 placement_properties:
   zone: "CRAZY_TOWN"
+
+disable_droplet_cache: false

--- a/lib/dea/config.rb
+++ b/lib/dea/config.rb
@@ -16,7 +16,8 @@ module Dea
       "placement_properties" => { "zone" => "default" },
       "instance" => { "cpu_limit_shares" => 256 },
       "staging" => { "cpu_limit_shares" => 512 },
-      "default_health_check_timeout" => 60
+      "default_health_check_timeout" => 60,
+      "disable_droplet_cache" => false
     }
 
     def self.schema
@@ -94,7 +95,9 @@ module Dea
             optional("enabled") => bool,
             optional("max_staging_duration") => Integer,
             optional("environment") => Hash
-          }
+          },
+
+          optional("disable_droplet_cache") => bool
         }
       end
     end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -57,5 +57,25 @@ module Dea
         end
       end
     end
+
+    describe "#disable_droplet_cache" do
+      subject(:config) { described_class.new(config_hash) }
+
+      context "when the config hash has no key for disable_droplet_cache:" do
+        let(:config_hash) { { } }
+
+        it "has a default value false" do
+          config["disable_droplet_cache"].should == false
+        end
+      end
+
+      context "when the config hash has a key for disable_droplet_cache:" do
+        let(:config_hash) { { "disable_droplet_cache" => true } }
+
+        it "uses the value provided by the hash" do
+          config["disable_droplet_cache"].should == true
+        end
+      end
+    end
   end
 end

--- a/spec/unit/starting/instance_spec.rb
+++ b/spec/unit/starting/instance_spec.rb
@@ -538,6 +538,7 @@ describe Dea::Instance do
       instance.stub(:promise_prepare_start_script).and_return(delivering_promise)
       instance.stub(:promise_exec_hook_script).with('before_start').and_return(delivering_promise)
       instance.stub(:promise_start).and_return(delivering_promise)
+      instance.stub(:promise_remove_droplet).and_return(delivering_promise)
       instance.stub(:promise_exec_hook_script).with('after_start').and_return(delivering_promise)
       instance.stub(:promise_health_check).and_return(delivering_promise(true))
       instance.stub(:droplet).and_return(droplet)
@@ -867,6 +868,35 @@ describe Dea::Instance do
           end
 
           instance.promise_start.resolve
+        end
+      end
+    end
+
+    describe "#promise_remove_droplet" do
+      before do
+        instance.unstub(:promise_remove_droplet)
+        droplet.stub(:destroy).and_yield
+      end
+
+      context "when config option disable_droplet_cache is set false" do
+        before do
+          bootstrap.config["disable_droplet_cache"] = false
+        end
+
+        it "should not remove the droplet cache" do
+          droplet.should_not_receive(:destroy)
+          expect_start.to_not raise_error
+        end
+      end
+
+      context "when config option disable_droplet_cache is set true" do
+        before do
+          bootstrap.config["disable_droplet_cache"] = true
+        end
+
+        it "should remove the droplet cache" do
+          droplet.should_receive(:destroy)
+          expect_start.to_not raise_error
         end
       end
     end


### PR DESCRIPTION
At present, when starting application from a DEA component, the app's droplet
file will be downloaded and cached in DEA. This mechanism will lead to some
issues in some resource restriction environments, as for some cases, the DEA
has a finite amount of disk capacity and if DEA caches the droplet files, the
disk space will run out. Also, for some security reasons, we don't want
everyone's app bits kept in the DEA.

As a result, it should be possible to disable the app bits cache in such
resource constrained and security sensitive environments. This patch provides
a config option for DEA named "disable_droplet_cache" to resolve this issue.
By default, this config option is false, when it is set true, DEA will remove
the droplet file cached in the base_dir/droplet/ folder after the instance of
an app is started.
