### PR TITLE
Only update routes for instances that are running

### DIFF
--- a/lib/dea/bootstrap.rb
+++ b/lib/dea/bootstrap.rb
@@ -377,28 +377,33 @@ module Dea
       app_version = message.data["version"]
 
       instance_registry.instances_for_application(app_id).dup.each do |_, instance|
-        current_uris = instance.application_uris
-
-        logger.debug("Mapping new URIs")
-        logger.debug("New: #{uris} Old: #{current_uris}")
-
-        new_uris = uris - current_uris
-        unless new_uris.empty?
-          router_client.register_instance(instance, :uris => new_uris)
-        end
-
-        obsolete_uris = current_uris - uris
-        unless obsolete_uris.empty?
-          router_client.unregister_instance(instance, :uris => obsolete_uris)
-        end
-
-        instance.application_uris = uris
+        next unless instance.running? || instance.evacuating?
+        update_app_uris(instance, uris)
 
         if app_version
           instance.application_version = app_version
           instance_registry.change_instance_id(instance)
         end
       end
+    end
+
+    def update_app_uris(instance, uris)
+      current_uris = instance.application_uris
+
+      logger.debug("Mapping new URIs")
+      logger.debug("New: #{uris} Old: #{current_uris}")
+
+      new_uris = uris - current_uris
+      unless new_uris.empty?
+        router_client.register_instance(instance, :uris => new_uris)
+      end
+
+      obsolete_uris = current_uris - uris
+      unless obsolete_uris.empty?
+        router_client.unregister_instance(instance, :uris => obsolete_uris)
+      end
+
+      instance.application_uris = uris
     end
 
     def handle_dea_find_droplet(message)


### PR DESCRIPTION
If an update message is processed by a an instance that is not in the
proper state, a router registration message may get published with port
0 as the target port.  This is, obviously, unreachable. :)

This change will prevent updates to app instances that aren't in an
appropropriate state.  When app update messages are skipped because of
incorrect state, the app instance version remains at the old level so
the health manager can detect the problem and correct it.
