### PR TITLE
Changed logging level of plugin config dump from info to debug.

### DIFF
--- a/lib/dea/staging/staging_task_workspace.rb
+++ b/lib/dea/staging/staging_task_workspace.rb
@@ -43,7 +43,7 @@ module Dea
         "buildpack_dirs" => @buildpack_manager.list
       }
 
-      logger.info plugin_config
+      logger.debug plugin_config
       File.open(plugin_config_path, 'w') { |f| YAML.dump(plugin_config, f) }
     end
 


### PR DESCRIPTION
The plugin config contains the application's environment which may contain sensitive data such as service credentials. Changing this to the debug logging level makes it easier to turn this off in production.
