### PR TITLE
DEA download error can leak credentials

### DIFF
--- a/lib/dea/utils/download.rb
+++ b/lib/dea/utils/download.rb
@@ -8,7 +8,7 @@ class Download
     def initialize(msg, data = {})
       @data = data
 
-      super("Error downloading: %s (%s)" % [uri, msg])
+      super("Error downloading: %s" % msg)
     end
 
     def uri

--- a/spec/unit/utils/download_spec.rb
+++ b/spec/unit/utils/download_spec.rb
@@ -96,3 +96,36 @@ describe Download do
     end
   end
 end
+
+describe Download::DownloadError do
+  let(:uri) { URI("http://user:password@example.com/droplet") }
+  let(:data) { {:droplet_uri => uri} }
+  let(:msg) { "Error message" }
+  let(:error) { Download::DownloadError.new(msg, data) }
+
+  it "should not contain credentials in the message" do
+    error.message.should_not match(/user/)
+    error.message.should_not match(/password/)
+  end
+
+  it "should not contain credentials when inspected" do
+    error.inspect.should_not match(/user/)
+    error.inspect.should_not match(/password/)
+  end
+
+  describe "#uri" do
+    context "when data contains droplet_uri" do
+      it "should return the uri" do
+        error.uri.should be(uri)
+      end
+    end
+
+    context "when data does not contain droplet_uri" do
+      let (:data) { {} }
+
+      it "should return '(unknown)'" do
+        error.uri.should eq("(unknown)")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Filter the credentials out of DownloadError's meessage and data bag.  Without this change, download failure exceptions can make it back to the end user with all credentials intact.

```
REQUEST: PUT https://api.10.244.0.34/v2/apps/a829b7a6-1e49-46b8-bad9-ec763af6107e
REQUEST_HEADERS:
  Authorization : [PRIVATE DATA HIDDEN]
  Content-Length : 34
  Content-Type : application/json
REQUEST_BODY: {"console":true,"state":"STARTED"}
RESPONSE: [400]
RESPONSE_HEADERS:
...
RESPONSE_BODY:
{
  "code":170001,
  "description":"Staging error: failed to stage application:\n
Error downloading: http://user:pass@10.244.0.22:9022/staging/apps/a829b7a6-1e49-46b8-bad9-ec763af6107e (Response status: unknown)",
  "error_code":"CF-StagingError",
...
```
