### PR TITLE
Handle URIs that fail to parse

### DIFF
--- a/lib/dea/staging/staging_message.rb
+++ b/lib/dea/staging/staging_message.rb
@@ -1,4 +1,6 @@
 require "dea/starting/start_message"
+require "steno"
+require "steno/core_ext"
 
 class StagingMessage
   def initialize(message)
@@ -43,7 +45,17 @@ class StagingMessage
 
   def admin_buildpacks
     (@message["admin_buildpacks"] || []).map do |buildpack|
-      { url: URI(buildpack["url"]), key: buildpack["key"] }
-    end
+      begin
+        { url: URI(buildpack["url"]), key: buildpack["key"] }
+      rescue => e
+        logger.log_exception(e)
+      end
+    end.compact
+  end
+
+  private
+
+  def logger
+    self.class.logger
   end
 end

--- a/spec/unit/staging/staging_message_spec.rb
+++ b/spec/unit/staging/staging_message_spec.rb
@@ -87,5 +87,16 @@ describe StagingMessage do
         }
       ])
     end
+
+    it "should handle invalid buildpack urls" do
+      admin_buildpacks[0]["url"] = nil
+
+      expect(message.admin_buildpacks).to eq([
+        {
+          url: URI("http://www.example.com/buildpacks/uri/second"),
+          key: "second"
+        }
+      ])
+    end
   end
 end


### PR DESCRIPTION
https://github.com/cloudfoundry/cloud_controller_ng/pull/159 exposed "bad" urls sent to the DEA
We saw the below in our logs

{"timestamp":1391435749.309297,"message":"staging.task.failed","log_level":"info","source":"Staging","data":{"app_guid":"13b010dc-8d26-4629-bc86-9ad09b87a88d","task_id":"05dece98d6984a31b67e3828be2ece5f","error":"bad argument (expected URI object or URI string)","backtrace":["/var/vcap/packages/ruby/lib/ruby/1.9.1/uri/common.rb:996:in `URI'","/var/vcap/packages/dea_next/lib/dea/staging/staging_message.rb:46:in`block in admin_buildpacks'","/var/vcap/packages/dea_next/lib/dea/staging/staging_message.rb:45:in `map'","/var/vcap/packages/dea_next/lib/dea/staging/staging_message.rb:45:in`admin_buildpacks'","/var/vcap/packages/dea_next/lib/dea/staging/staging_task_workspace.rb:18:in `initialize'","/var/vcap/packages/dea_next/lib/dea/staging/staging_task.rb:82:in`new'","/var/vcap/packages/dea_next/lib/dea/staging/staging_task.rb:82:in `workspace'","/var/vcap/packages/dea_next/lib/dea/staging/staging_task.rb:94:in`streaming_log_url'","/var/vcap/packages/dea_next/lib/dea/responders/staging.rb:119:in `block in notify_setup_completion'","/var/vcap/packages/dea_next/lib/dea/staging/staging_task.rb:142:in`call'","/var/vcap/packages/dea_next/lib/dea/staging/staging_task.rb:142:in `trigger_after_setup'","/var/vcap/packages/dea_next/lib/dea/staging/staging_task.rb:518:in`rescue in resolve_staging_setup'","/var/vcap/packages/dea_next/lib/dea/staging/staging_task.rb:497:in `resolve_staging_setup'","/var/vcap/packages/dea_next/lib/dea/staging/staging_task.rb:45:in`block in start'","/var/vcap/packages/dea_next/lib/dea/promise.rb:80:in `call'","/var/vcap/packages/dea_next/lib/dea/promise.rb:80:in`block in run'"]},"thread_id":8960140,"fiber_id":25176740,"process_id":15799,"file":"/var/vcap/packages/dea_next/lib/dea/staging/staging_task.rb","lineno":53,"method":"block in start"} 
