### PR TITLE
Add info about buildpack used to staging response

### DIFF
--- a/buildpacks/lib/buildpack.rb
+++ b/buildpacks/lib/buildpack.rb
@@ -80,6 +80,7 @@ module Buildpacks
 
     def save_buildpack_info
       buildpack_info = {
+        "buildpack_path" => build_pack.path,
         "detected_buildpack"  => build_pack.name,
         "start_command" => start_command
       }
@@ -130,7 +131,7 @@ module Buildpacks
 
     def buildpack_with_key(buildpack_key)
       detected_buildpack_dir = buildpack_dirs.find do |dir|
-        File.basename(dir) == specified_buildpack_key
+        File.basename(dir) == buildpack_key
       end
       Buildpacks::Installer.new(detected_buildpack_dir, app_dir, cache_dir)
     end

--- a/lib/dea/responders/staging.rb
+++ b/lib/dea/responders/staging.rb
@@ -126,6 +126,8 @@ module Dea::Responders
           task_id: task.task_id,
           error: (error.to_s if error),
           detected_buildpack: task.detected_buildpack,
+          buildpack_key: task.buildpack_key,
+          buildpack_url: task.buildpack_url,
           droplet_sha1: task.droplet_sha1
         })
 
@@ -164,6 +166,8 @@ module Dea::Responders
         'task_id' => params[:task_id],
         'task_streaming_log_url' => params[:streaming_log_url],
         'detected_buildpack' => params[:detected_buildpack],
+        'buildpack_key' => params[:buildpack_key],
+        'buildpack_url' => params[:buildpack_url],
         'error' => params[:error],
         'droplet_sha1' => params[:droplet_sha1]
       )

--- a/lib/dea/staging/buildpack_manager.rb
+++ b/lib/dea/staging/buildpack_manager.rb
@@ -2,49 +2,75 @@ require "dea/staging/admin_buildpack_downloader"
 
 module Dea
   class BuildpackManager
-    def initialize (admin_buildpacks_dir, system_buildpacks_dir, admin_buildpacks, buildpacks_in_use)
+    def initialize (admin_buildpacks_dir, system_buildpacks_dir, staging_message, buildpacks_in_use)
       @admin_buildpacks_dir = admin_buildpacks_dir
       @system_buildpacks_dir = system_buildpacks_dir
-      @admin_buildpacks = admin_buildpacks
+      @staging_message = staging_message
       @buildpacks_in_use = buildpacks_in_use
     end
 
     def download
-      AdminBuildpackDownloader.new(@admin_buildpacks, @admin_buildpacks_dir).download
+      AdminBuildpackDownloader.new(@staging_message.admin_buildpacks, @admin_buildpacks_dir).download
     end
 
     def clean
-      buildpacks_needing_deletion.each do |path|
+      buildpack_paths_needing_deletion.each do |path|
         FileUtils.rm_rf(path)
       end
     end
 
-    def list
-      admin_buildpacks_in_staging_message + system_buildpack_paths
+    def buildpack_dirs
+      admin_buildpacks + system_buildpacks
+    end
+
+    def buildpack_key(buildpack_dir)
+      return nil unless buildpack_dir
+      path = Pathname.new(buildpack_dir)
+      return nil unless admin_buildpack_path?(path)
+      path.basename.to_s
+    end
+
+    def system_buildpack_url(buildpack_dir)
+      return nil unless buildpack_dir
+      path = Pathname.new(buildpack_dir)
+      return nil unless system_buildpack_path?(path)
+      URI("buildpack:system:#{path.basename.to_s}")
     end
 
     private
 
-    def buildpacks_needing_deletion
-      all_buildpack_paths - (admin_buildpacks_in_staging_message + buildpacks_in_use_paths)
+    def buildpack_paths_needing_deletion
+      local_admin_buildpack_paths - (admin_buildpacks.map{ |b| Pathname.new(b) } + buildpacks_in_use_paths)
     end
 
-    def admin_buildpacks_in_staging_message
-      @admin_buildpacks.map do |buildpack|
-        Pathname.new(File.join(@admin_buildpacks_dir, buildpack[:key]))
-      end.select{ |path| File.exists? path }.map(&:to_s)
+    def admin_buildpacks
+      @staging_message.admin_buildpacks.map do |buildpack|
+        File.join(@admin_buildpacks_dir, buildpack[:key])
+      end.select{ |dir| File.exists?(dir) }.map(&:to_s)
+    end
+
+    def system_buildpacks
+      system_buildpack_paths.map(&:to_s)
     end
 
     def buildpacks_in_use_paths
-      @buildpacks_in_use.map { |b| File.join(@admin_buildpacks_dir, b[:key]).to_s }
+      @buildpacks_in_use.map { |b| Pathname.new(@admin_buildpacks_dir).join(b[:key]) }
     end
 
-    def all_buildpack_paths
-      Pathname.new(@admin_buildpacks_dir).children.map(&:to_s)
+    def local_admin_buildpack_paths
+      Pathname.new(@admin_buildpacks_dir).children
     end
 
     def system_buildpack_paths
-      Pathname.new(@system_buildpacks_dir).children.sort.map(&:to_s)
+      Pathname.new(@system_buildpacks_dir).children.sort
+    end
+
+    def admin_buildpack_path?(path)
+      local_admin_buildpack_paths.include?(path)
+    end
+
+    def system_buildpack_path?(path)
+      system_buildpack_paths.include?(path)
     end
   end
 end

--- a/lib/dea/staging/staging_message.rb
+++ b/lib/dea/staging/staging_message.rb
@@ -53,6 +53,15 @@ class StagingMessage
     end.compact
   end
 
+  def buildpack_git_url
+    url = properties["buildpack"] || properties["buildpack_git_url"]
+    URI(url) if url
+  end
+
+  def buildpack_key
+    properties["buildpack_key"]
+  end
+
   private
 
   def logger

--- a/lib/dea/staging/staging_task.rb
+++ b/lib/dea/staging/staging_task.rb
@@ -83,6 +83,14 @@ module Dea
     def workspace
       @workspace ||= StagingTaskWorkspace.new(
         config['base_dir'],
+        staging_message.properties
+      )
+    end
+
+    def buildpack_manager
+      @buildpack_manager ||= BuildpackManager.new(
+        workspace.admin_buildpacks_dir,
+        workspace.system_buildpacks_dir,
         staging_message,
         @buildpacks_in_use
       )
@@ -102,6 +110,18 @@ module Dea
 
     def detected_buildpack
       task_info['detected_buildpack']
+    end
+
+    def buildpack_path
+      task_info['buildpack_path']
+    end
+
+    def buildpack_url
+      staging_message.buildpack_git_url || buildpack_manager.system_buildpack_url(buildpack_path)
+    end
+
+    def buildpack_key
+      staging_message.buildpack_key || buildpack_manager.buildpack_key(buildpack_path)
     end
 
     def memory_limit_mb
@@ -526,7 +546,7 @@ module Dea
     end
 
     def resolve_staging_setup
-      workspace.prepare
+      workspace.prepare(buildpack_manager)
       with_network = false
       container.create_container(
         bind_mounts: bind_mounts,

--- a/lib/dea/staging/staging_task_workspace.rb
+++ b/lib/dea/staging/staging_task_workspace.rb
@@ -1,5 +1,4 @@
 require "fileutils"
-require "dea/staging/admin_buildpack_downloader"
 require "dea/staging/buildpack_manager"
 
 module Dea
@@ -9,15 +8,9 @@ module Dea
     STAGING_LOG = "staging_task.log".freeze
     STAGING_INFO = "staging_info.yml".freeze
 
-    def initialize(base_dir, staging_message, buildpacks_in_use)
+    def initialize(base_dir, properties)
       @base_dir = base_dir
-      @environment_properties = staging_message.properties
-      @buildpack_manager = Dea::BuildpackManager.new(
-        admin_buildpacks_dir,
-        File.join(buildpack_dir, "vendor"),
-        staging_message.admin_buildpacks,
-        buildpacks_in_use
-      )
+      @environment_properties = properties
     end
 
     ###### Setup
@@ -33,26 +26,28 @@ module Dea
       end
     end
 
-    def write_config_file
+    def write_config_file(buildpack_dirs)
       plugin_config = {
         "source_dir" => warden_unstaged_dir,
         "dest_dir" => warden_staged_dir,
         "cache_dir" => warden_cache,
         "environment" => @environment_properties,
         "staging_info_name" => STAGING_INFO,
-        "buildpack_dirs" => @buildpack_manager.list
+        "buildpack_dirs" => buildpack_dirs
       }
 
       logger.debug plugin_config
       File.open(plugin_config_path, 'w') { |f| YAML.dump(plugin_config, f) }
     end
 
-    def prepare
+    private :write_config_file
+
+    def prepare(buildpack_manager)
       FileUtils.mkdir_p(tmpdir)
       FileUtils.mkdir_p(admin_buildpacks_dir)
-      @buildpack_manager.download
-      @buildpack_manager.clean
-      write_config_file
+      buildpack_manager.download
+      buildpack_manager.clean
+      write_config_file(buildpack_manager.buildpack_dirs)
     end
 
     ###### Accessors
@@ -91,6 +86,10 @@ module Dea
 
     def buildpack_dir
       File.expand_path("../../../../buildpacks", __FILE__)
+    end
+
+    def system_buildpacks_dir
+      File.join(buildpack_dir, "vendor")
     end
 
     def warden_staging_log

--- a/spec/unit/buildpack/buildpack_spec.rb
+++ b/spec/unit/buildpack/buildpack_spec.rb
@@ -143,6 +143,18 @@ describe Buildpacks::Buildpack, type: :buildpack do
         expect(buildpack_info["detected_buildpack"]).to eq("Node.js")
       end
 
+      it "has the buildpack path" do
+        expect(buildpack_info["buildpack_path"]).to eq("#{fake_buildpacks_dir}/no_start_command")
+      end
+
+      it "has a nil specified_buildpack_key" do
+        expect(buildpack_info["specified_buildpack_key"]).to be_nil
+      end
+
+      it "has a nil custom buildpack url" do
+        expect(buildpack_info["custom_buildpack_url"]).to be_nil
+      end
+
       context "when the application has a procfile" do
         it "uses the start command specified by the 'web' key in the procfile" do
           expect(buildpack_info["start_command"]).to eq("node app.js --from-procfile=true")
@@ -267,4 +279,3 @@ describe Buildpacks::Buildpack, type: :buildpack do
     end
   end
 end
-

--- a/spec/unit/responders/staging_spec.rb
+++ b/spec/unit/responders/staging_spec.rb
@@ -14,12 +14,16 @@ describe Dea::Responders::Staging do
   let(:snapshot) { double(:snapshot, :save => nil, :load => nil)}
   let(:bootstrap) { double(:bootstrap, :config => config, :snapshot => snapshot) }
   let(:staging_task_registry) { Dea::StagingTaskRegistry.new }
+  let(:buildpack_url) { nil }
+  let(:buildpack_key) { nil }
   let(:staging_task) do
     double(:staging_task,
       staging_message: staging_message,
       task_id: "task-id",
       task_log: "task-log",
       detected_buildpack: nil,
+      buildpack_key: buildpack_key,
+      buildpack_url: buildpack_url,
       droplet_sha1: "some-droplet-sha",
       memory_limit_mb: 1,
       disk_limit_mb: 2
@@ -221,6 +225,8 @@ describe Dea::Responders::Staging do
               "task_id" => "task-id",
               "task_streaming_log_url" => "streaming-log-url",
               "detected_buildpack" => nil,
+              "buildpack_key" => nil,
+              "buildpack_url" => nil,
               "error" => nil,
               "droplet_sha1" => nil
             ))
@@ -236,6 +242,8 @@ describe Dea::Responders::Staging do
               "task_id" => "task-id",
               "task_streaming_log_url" => "streaming-log-url",
               "detected_buildpack" => nil,
+              "buildpack_key" => nil,
+              "buildpack_url" => nil,
               "error" => "error-description",
               "droplet_sha1" => nil
             ))
@@ -246,6 +254,9 @@ describe Dea::Responders::Staging do
 
       describe "after staging completed" do
         context "when successfully" do
+          let(:buildpack_url) { "https://example.com/repo.git" }
+          let(:buildpack_key) { "some_buildpack_key" }
+
           before do
             staging_task.stub(:after_complete_callback).and_yield(nil)
             bootstrap.stub(:start_app)
@@ -256,6 +267,8 @@ describe Dea::Responders::Staging do
               "task_id" => "task-id",
               "task_streaming_log_url" => nil,
               "detected_buildpack" => nil,
+              "buildpack_key" => "some_buildpack_key",
+              "buildpack_url" => "https://example.com/repo.git",
               "error" => nil,
               "droplet_sha1" => "some-droplet-sha"
             ))
@@ -310,6 +323,8 @@ describe Dea::Responders::Staging do
               "task_id" => "task-id",
               "task_streaming_log_url" => nil,
               "detected_buildpack" => nil,
+              "buildpack_key" => nil,
+              "buildpack_url" => nil,
               "error" => "error-description",
               "droplet_sha1" => nil
             ))
@@ -346,6 +361,8 @@ describe Dea::Responders::Staging do
               "task_id" => "task-id",
               "task_streaming_log_url" => nil,
               "detected_buildpack" => nil,
+              "buildpack_key" => nil,
+              "buildpack_url" => nil,
               "error" => "Error staging: task stopped",
               "droplet_sha1" => nil
             ))
@@ -400,6 +417,8 @@ describe Dea::Responders::Staging do
             "task_id" => staging_task.task_id,
             "task_streaming_log_url" => nil,
             "detected_buildpack" => nil,
+            "buildpack_key" => nil,
+            "buildpack_url" => nil,
             "error" => "Not enough memory resources available",
             "droplet_sha1" => nil
           }

--- a/spec/unit/staging/buildpack_manager_spec.rb
+++ b/spec/unit/staging/buildpack_manager_spec.rb
@@ -1,27 +1,28 @@
 require 'spec_helper'
 require 'dea/staging/buildpack_manager'
+require 'dea/staging/staging_message'
 
 describe Dea::BuildpackManager do
   let(:base_dir) { Dir.mktmpdir }
   let(:admin_buildpacks_dir) { "#{base_dir}/admin_buildpacks" }
   let(:system_buildpacks_dir) { "#{base_dir}/system_buildpacks" }
-  let(:admin_buildpacks) do
-    [
-      {
-        url: URI("http://example.com/buildpacks/uri/abcdef"),
-        key: "abcdef"
-      }
-    ]
-  end
-
+  let(:admin_buildpacks) { [{url: URI("http://example.com/buildpacks/uri/abcdef"), key: "abcdef"}] }
   let(:buildpacks_in_use) { [] }
 
-  after { FileUtils.rm_f(base_dir) }
+  let(:staging_message) do
+    attributes = valid_staging_attributes
+    attributes['admin_buildpacks'] = admin_buildpacks.map do |bp|
+      { "url" => bp[:url].to_s, "key" => bp[:key] }
+    end
+    StagingMessage.new(attributes)
+  end
 
-  subject(:manager) { Dea::BuildpackManager.new(admin_buildpacks_dir, system_buildpacks_dir, admin_buildpacks, buildpacks_in_use) }
+  after { FileUtils.rm_rf(base_dir) }
+
+  subject(:manager) { Dea::BuildpackManager.new(admin_buildpacks_dir, system_buildpacks_dir, staging_message, buildpacks_in_use) }
 
   def create_populated_directory(path)
-    FileUtils.mkdir_p(File.join(path, "a_buildpack_file"))
+    FileUtils.mkdir_p(File.join(path, "a_buildpack_file")) if path
   end
 
   describe "#download" do
@@ -57,7 +58,7 @@ describe Dea::BuildpackManager do
     end
 
     context "when an admin buildpack is in use" do
-      let(:buildpacks_in_use) { [{uri: URI("http://www.google.com"), key: "efghi"}] }
+      let(:buildpacks_in_use) { [{uri: URI("http://www.example.com"), key: "efghi"}] }
 
       let(:file_in_use) {File.join(admin_buildpacks_dir, "efghi")}
 
@@ -77,62 +78,151 @@ describe Dea::BuildpackManager do
     end
   end
 
-  describe "#list" do
+  describe "#buildpack_dirs" do
     let(:system_buildpack) { File.join(system_buildpacks_dir, "abcdef") }
+
+    let(:admin_buildpacks) do
+      [
+        {
+          url: "http://example.com/buildpacks/uri/z_admin",
+          key: "z_admin"
+        },
+        {
+          url: "http://example.com/buildpacks/uri/admin",
+          key: "admin"
+        },
+        {
+          url: "http://example.com/buildpacks/uri/another_admin",
+          key: "another_admin"
+        }
+      ]
+    end
 
     before do
       create_populated_directory(system_buildpack)
     end
 
     context "when there are multiple system buildpacks" do
-      let(:additional_system_buildpacks) { [File.join(system_buildpacks_dir, "abc"),File.join(system_buildpacks_dir, "def")]}
+      let(:additional_system_buildpacks) do
+        [
+          File.join(system_buildpacks_dir, "abc"),
+          File.join(system_buildpacks_dir, "def")
+        ]
+      end
 
-      before {additional_system_buildpacks.each {|path| create_populated_directory(path)}}
+      before { additional_system_buildpacks.each {|path| create_populated_directory(path)} }
 
-      after {FileUtils.rm_rf(additional_system_buildpacks)}
+      after { FileUtils.rm_rf(additional_system_buildpacks) }
 
       it "has a sorted list of system buildpacks" do
         sorted_buildpacks = additional_system_buildpacks.dup
         sorted_buildpacks << system_buildpack
-        expect(manager.list).to eq(sorted_buildpacks.sort)
+        expect(manager.buildpack_dirs).to eq(sorted_buildpacks.sort)
       end
     end
 
-    context "when there are admin buildpacks" do
-      let(:admin_buildpacks) do
-        [
-          {
-            url: "http://example.com/buildpacks/uri/admin",
-            key: "admin"
-          },
-          {
-            url: "http://example.com/buildpacks/uri/cant_find_admin",
-            key: "cant_find_admin"
-          }
-        ]
+    context "when admin buildpacks have been downloaded" do
+      before do
+        admin_buildpacks.each do |bp|
+          create_populated_directory(File.join(admin_buildpacks_dir, bp[:key]))
+        end
       end
-
-      let(:admin_buildpack) { File.join(admin_buildpacks_dir, "admin") }
-
-      before { create_populated_directory(admin_buildpack) }
 
       it "has the correct number of buildpacks" do
-        expect(manager.list).to have(2).item
+        expect(manager.buildpack_dirs).to have(4).item
       end
 
-      it "copes with an admin buildpack not being there" do
-        expect(manager.list).to include("#{admin_buildpacks_dir}/admin")
+      it "returns the buildpacks in the same order as the staging message" do
+        expect(manager.buildpack_dirs[0]).to eq(File.join(admin_buildpacks_dir, "z_admin"))
+        expect(manager.buildpack_dirs[1]).to eq(File.join(admin_buildpacks_dir, "admin"))
+        expect(manager.buildpack_dirs[2]).to eq(File.join(admin_buildpacks_dir, "another_admin"))
       end
 
-      it "includes the admin buildpacks which is there" do
-        expect(manager.list).to_not include("#{admin_buildpacks_dir}/cant_find_admin")
+      context "when stale admin buildpacks still exist on disk" do
+        it "only returns buildpacks specified in staging message" do
+          create_populated_directory(File.join(admin_buildpacks_dir, "not_in_staging_message"))
+          expect(manager.buildpack_dirs).to have(4).item
+        end
+      end
+
+      context "when a buildpack from the staging message does not exist on disk" do
+        before { FileUtils.rm_rf("#{admin_buildpacks_dir}/z_admin") }
+
+        it "copes with an admin buildpack not being there" do
+          expect(manager.buildpack_dirs).to include("#{admin_buildpacks_dir}/admin")
+          expect(manager.buildpack_dirs).to include("#{admin_buildpacks_dir}/another_admin")
+        end
+
+        it "should not include admin buildpacks which are missing" do
+          expect(manager.buildpack_dirs).to_not include("#{admin_buildpacks_dir}/z_admin")
+        end
+
+        it "includes the system buildpacks" do
+          expect(manager.buildpack_dirs).to include("#{system_buildpacks_dir}/abcdef")
+        end
       end
     end
 
-    context "when there are no admin buildpacks" do
+    context "when there are no admin buildpacks on disk" do
       it "includes the system buildpacks" do
-        expect(manager.list).to have(1).item
-        expect(manager.list).to include("#{system_buildpacks_dir}/abcdef")
+        expect(manager.buildpack_dirs).to have(1).item
+        expect(manager.buildpack_dirs).to include("#{system_buildpacks_dir}/abcdef")
+      end
+    end
+
+    context "when there are no buildpacks (admin or system)" do
+      let(:system_buildpack) { nil }
+
+      before { FileUtils.mkdir_p(system_buildpacks_dir) }
+
+      it "should return an empty list" do
+        expect(manager.buildpack_dirs).to be_empty
+      end
+    end
+  end
+
+  describe "buildpack keys and urls" do
+    let(:system_buildpack) { File.join(system_buildpacks_dir, "java") }
+    let(:admin_buildpack) { File.join(admin_buildpacks_dir, "admin") }
+
+    before do
+      create_populated_directory(system_buildpack)
+      create_populated_directory(admin_buildpack)
+    end
+
+    describe "#buildpack_key" do
+      it "should be the buildpack key for an admin buildpack" do
+        expect(subject.buildpack_key(admin_buildpack)).to eq("admin")
+      end
+
+      it "should be nil for a system buildpack" do
+        expect(subject.buildpack_key(system_buildpack)).to be_nil
+      end
+
+      it "should be nil for a custom buildpack" do
+        expect(subject.buildpack_key("/tmp/cloned")).to be_nil
+      end
+
+      it "should be nil for a nil buildpack dir" do
+        expect(subject.buildpack_key(nil)).to be_nil
+      end
+    end
+
+    describe "#system_buildpack_url" do
+      it "should be a system buildpack url for a system buildpack" do
+        expect(subject.system_buildpack_url(system_buildpack)).to eq(URI("buildpack:system:java"))
+      end
+
+      it "should be nil for an admin buildpack" do
+        expect(subject.system_buildpack_url(admin_buildpack)).to be_nil
+      end
+
+      it "should be nil for a custom buildpack" do
+        expect(subject.system_buildpack_url("/tmp/cloned")).to be_nil
+      end
+
+      it "should be nil for a nil buildpack dir" do
+        expect(subject.system_buildpack_url(nil)).to be_nil
       end
     end
   end

--- a/spec/unit/staging/staging_task_spec.rb
+++ b/spec/unit/staging/staging_task_spec.rb
@@ -253,6 +253,102 @@ YAML
     end
   end
 
+  describe '#buildpack_path' do
+    before do
+      contents = <<YAML
+---
+buildpack_path: some/buildpack/path
+YAML
+      staging_info = File.join(workspace_dir, 'staging_info.yml')
+      File.open(staging_info, 'w') { |f| f.write(contents) }
+    end
+
+    it 'returns the buildpack path' do
+      staging_task.buildpack_path.should eq('some/buildpack/path')
+    end
+  end
+
+  describe '#buildpack_url' do
+    let(:buildpack_path) { "#{staging_task.workspace.system_buildpacks_dir}/java" }
+
+    before do
+      contents = <<YAML
+---
+buildpack_path: #{buildpack_path}
+YAML
+      staging_info = File.join(workspace_dir, 'staging_info.yml')
+      File.open(staging_info, 'w') { |f| f.write(contents) }
+    end
+
+    context 'when a detected system buildpack is used' do
+      it 'returns the correct system buildpack url' do
+        staging_task.buildpack_url.should eq(URI('buildpack:system:java'))
+      end
+    end
+
+    context 'when a custom buildpack is used' do
+      let(:attributes) do
+        staging_attributes = valid_staging_attributes
+        staging_attributes['properties']['buildpack_git_url'] = 'https://example.com/repo.git'
+        staging_attributes
+      end
+
+      it 'returns the custom buildpack url' do
+        staging_task.buildpack_url.should eq(URI('https://example.com/repo.git'))
+      end
+    end
+
+    context 'when an admin buildpack is used' do
+      let(:buildpack_path) { "#{staging_task.workspace.admin_buildpacks_dir}/admin_key" }
+
+      it 'returns a nil buildpack url' do
+        staging_task.buildpack_url.should be_nil
+      end
+    end
+  end
+
+  describe '#buildpack_key' do
+    let(:buildpack_path) { "#{staging_task.workspace.admin_buildpacks_dir}/admin_key" }
+
+    before do
+      FileUtils.mkdir_p(staging_task.workspace.admin_buildpacks_dir)
+      FileUtils.mkdir_p(buildpack_path)
+      contents = <<YAML
+---
+buildpack_path: #{buildpack_path}
+YAML
+      staging_info = File.join(workspace_dir, 'staging_info.yml')
+      File.open(staging_info, 'w') { |f| f.write(contents) }
+    end
+
+    context 'when an admin buildpack is detected' do
+      it 'returns the correct buildpack key' do
+        staging_task.buildpack_key.should eq('admin_key')
+      end
+    end
+
+    context 'when an admin buildpack is specified' do
+      let(:buildpack_path) { "#{staging_task.workspace.admin_buildpacks_dir}/ignored" }
+      let(:attributes) do
+        staging_attributes = valid_staging_attributes
+        staging_attributes['properties']['buildpack_key'] = 'specified_admin_key'
+        staging_attributes
+      end
+
+      it 'returns the specified admin key' do
+        staging_task.buildpack_key.should eq('specified_admin_key')
+      end
+    end
+
+    context 'when a detected system buildpack is used' do
+      let(:buildpack_path) { "#{staging_task.workspace.system_buildpacks_dir}/java" }
+
+      it 'returns a nil buildpack key' do
+        staging_task.buildpack_key.should be_nil
+      end
+    end
+  end
+
   describe '#streaming_log_url' do
     let(:url) { staging_task.streaming_log_url }
 
@@ -533,7 +629,14 @@ YAML
     end
 
     context 'when buildpack_cache_download_uri is provided' do
-      subject(:staging_task) { Dea::StagingTask.new(bootstrap, dir_server, StagingMessage.new(attributes.merge('buildpack_cache_download_uri' => 'http://www.someurl.com')), buildpacks_in_use) }
+      subject(:staging_task) do
+        Dea::StagingTask.new(
+          bootstrap,
+          dir_server,
+          StagingMessage.new(attributes.merge('buildpack_cache_download_uri' => 'http://www.someurl.com')),
+          buildpacks_in_use
+        )
+      end
 
       it 'downloads buildpack cache' do
         staging_task.should_receive(:promise_buildpack_cache_download)
@@ -772,7 +875,7 @@ YAML
 
   describe '#promise_buildpack_cache_download' do
     subject do
-      staging_task.workspace.prepare
+      staging_task.workspace.prepare(staging_task.buildpack_manager)
       promise = staging_task.promise_buildpack_cache_download
       promise.resolve
       promise


### PR DESCRIPTION
The goal is to get information about the buildpack used for staging (including detected admin buildpacks) back to the CC so it can be used to populate app usage events.  This intended to be part of the resolution to cloudfoundry/cloud_controller_ng#178.

Highlights:
- Add the path of buildpack used for staging to staging_info.yml so the buildpack manager can be used to detect its type
- Refactor buildpack manager out of the staging workspace
  - The staging task now creates and holds a reference to the buildpack manager
  - The buildpack manager is passed to workspace prepare so prepare can get the list of buildpack directories
  - The buildpack ordering tests were consolidated in the buildpack manager specs
- Added methods to buildpack manager to return the buildpack key or a system buildpack url from a path
- Return the buildpack url (system or custom) and the buildpack key in the staging complete message

I'm not particularly happy with the names `buildpack_url` and `buildpack_key` in the response so if there are better suggestions, please let me know.

As always, this is a proposal so I'm happy to work out the details.

/cc @markkropf @fraenkel
