### PR TITLE
Expose available_disk in stager advertisement

### DIFF
--- a/lib/dea/responders/staging_locator.rb
+++ b/lib/dea/responders/staging_locator.rb
@@ -33,7 +33,8 @@ module Dea::Responders
       nats.publish("staging.advertise", {
         "id" => dea_id,
         "stacks" => config["stacks"],
-        "available_memory" => resource_manager.remaining_memory
+        "available_memory" => resource_manager.remaining_memory,
+        "available_disk" => resource_manager.remaining_disk,
       })
     rescue => e
       logger.error("staging_locator.advertise", error: e, backtrace: e.backtrace)

--- a/spec/unit/responders/staging_locator_spec.rb
+++ b/spec/unit/responders/staging_locator_spec.rb
@@ -100,11 +100,13 @@ describe Dea::Responders::StagingLocator do
     it "publishes 'staging.advertise' message" do
       config["stacks"] = ["lucid64"]
       resource_manager.stub(:remaining_memory => 45678)
+      resource_manager.stub(:remaining_disk => 12345)
 
       nats_mock.should_receive(:publish).with("staging.advertise", JSON.dump(
         "id" => dea_id,
         "stacks" => ["lucid64"],
         "available_memory" => 45678,
+        "available_disk" => 12345,
       ))
       subject.advertise
     end


### PR DESCRIPTION
Cloud controller already makes sure it only attempts to start (as opposed to stage) on DEAs with enough disk, but it doesn't currently check whether stagers have enough disk before staging. This results in errors when a CC attempts to start on a DEA that's out of disk, which then refuses the request. This change exposes available_disk in the staging advertisement so that CC can know if a staging request is going to fail before it sends it to the DEA (exactly as already happens for start requests). 
