### PR TITLE
Add a way to wait for all parallel promises to complete

### DIFF
--- a/lib/dea/promise.rb
+++ b/lib/dea/promise.rb
@@ -31,6 +31,18 @@ module Dea
         promises.each(&:run).each(&:resolve)
       end
 
+      def run_in_parallel_and_join(*promises)
+        failure = nil
+        promises.each(&:run).each{ |p|
+          begin
+            p.resolve
+          rescue => error
+            failure = error if failure.nil?
+          end
+        }
+        raise failure if failure
+      end
+
       def run_serially(*promises)
         promises.each(&:resolve)
       end

--- a/lib/dea/staging/staging_task.rb
+++ b/lib/dea/staging/staging_task.rb
@@ -531,8 +531,8 @@ module Dea
       )
       promises = [promise_app_download]
       promises << promise_buildpack_cache_download if staging_message.buildpack_cache_download_uri
-
       Promise.run_in_parallel(*promises)
+
       promise_update = Promise.new do |p|
         container.update_path_and_ip
         p.deliver

--- a/lib/dea/starting/instance.rb
+++ b/lib/dea/starting/instance.rb
@@ -471,16 +471,16 @@ module Dea
         promise_state(State::BORN, State::STARTING).resolve
 
         # Concurrently download droplet and setup container
-        [
+        Promise.run_in_parallel_and_join(
           promise_droplet,
           promise_container
-        ].each(&:run).each(&:resolve)
+        )
 
-        [
+        Promise.run_serially(
           promise_extract_droplet,
           promise_exec_hook_script('before_start'),
           promise_start
-        ].each(&:resolve)
+        )
 
         on(Transition.new(:starting, :crashed)) do
           cancel_health_check


### PR DESCRIPTION
The problem doesn't appear until you start mixing threads (EM) and Fibers.
