### PR TITLE
Subtract inactive_file from memory usage

### DIFF
--- a/lib/dea/stat_collector.rb
+++ b/lib/dea/stat_collector.rb
@@ -90,7 +90,7 @@ module Dea
     end
 
     def compute_memory_usage(memory_stat)
-      return memory_stat.total_rss + memory_stat.total_cache
+      return memory_stat.total_rss + memory_stat.total_cache - memory_stat.total_inactive_file
     end
   end
 end

--- a/spec/unit/stat_collector_spec.rb
+++ b/spec/unit/stat_collector_spec.rb
@@ -8,10 +8,12 @@ describe Dea::StatCollector do
 
   let(:memory_stat_response) do
     Warden::Protocol::InfoResponse::MemoryStat.new(
-      :cache => 1,
-      :rss => 2,
-      :total_cache => 100,
-      :total_rss => 200
+      :cache => 20,
+      :inactive_file => 10,
+      :rss => 50,
+      :total_cache => 200,
+      :total_inactive_file => 100,
+      :total_rss => 500
     )
   end
 
@@ -118,7 +120,7 @@ describe Dea::StatCollector do
 
       before { collector.retrieve_stats(Time.now) }
 
-      its(:used_memory_in_bytes) { should eq(300) }
+      its(:used_memory_in_bytes) { should eq(600) }
       its(:used_disk_in_bytes) { should eq(42) }
       its(:computed_pcpu) { should eq(0) }
     end


### PR DESCRIPTION
Depending on which way you want to go with story [69951118](https://www.pivotaltracker.com/story/show/69951118), this implements the change to remove the `inactive_file` portion of the cache from the reported memory usage statistic.  The most notable impact is that the usage reported immediately after start went from ~70M to about ~22M with a simple ruby app.

For the test listed in the story, I actually created a 500M file in the container after pushing the app.  The memory usage reported went from 22.0M to 22.7M even though the cgroup's memory.usage_in_bytes statistic went from 73740288 bytes to 266739712 bytes.  (The container's memory limit was 256M.)

Please see the mailing list thread I pointed out in tracker for some of the discussion that occurred when I initially made this proposal.
