### PR TITLE
Fix log set wrong destination path

### DIFF
--- a/lib/dea/staging/staging_task.rb
+++ b/lib/dea/staging/staging_task.rb
@@ -465,7 +465,7 @@ module Dea
     def promise_copy_out_buildpack_cache
       Promise.new do |p|
         logger.info('staging.buildpack-cache.copying-out',
-                    source: workspace.warden_staged_buildpack_cache, destination: workspace.staged_droplet_path)
+                    source: workspace.warden_staged_buildpack_cache, destination: workspace.staged_droplet_dir)
 
         copy_out_request(workspace.warden_staged_buildpack_cache, workspace.staged_droplet_dir)
 


### PR DESCRIPTION
In function promise_copy_out_buildpack_cache: the "destination: workspace.staged_droplet_path" should be "destination: workspace.staged_droplet_dir"

Issue: #124
