### PR TITLE
add support for creating kernel core directory while starting the instance

### DIFF
--- a/lib/dea/starting/instance.rb
+++ b/lib/dea/starting/instance.rb
@@ -387,6 +387,17 @@ module Dea
       end
     end
 
+    def promise_setup_kernel_core_directory
+      Promise.new do |p|
+        if bootstrap.config['kernel'] && bootstrap.config['kernel']['core_directory']
+          core_directory = bootstrap.config['kernel']['core_directory']
+          script = 'mkdir -p ' + core_directory + ' && chown vcap:vcap ' + core_directory
+          container.run_script(:app, script, true)
+        end
+        p.deliver
+      end
+    end
+
     def promise_setup_environment
       Promise.new do |p|
         script = 'cd / && mkdir -p home/vcap/app && chown vcap:vcap home/vcap/app && ln -s home/vcap/app /app'
@@ -523,6 +534,7 @@ module Dea
         attributes['warden_handle'] = container.handle
 
         promise_setup_environment.resolve
+        promise_setup_kernel_core_directory.resolve
         p.deliver
       end
     end

--- a/spec/unit/starting/instance_spec.rb
+++ b/spec/unit/starting/instance_spec.rb
@@ -549,6 +549,7 @@ describe Dea::Instance do
       instance.container.stub(:get_connection).and_raise('bad connection bad')
       instance.container.stub(:create_container)
       instance.stub(:promise_setup_environment).and_return(delivering_promise)
+      instance.stub(:promise_setup_kernel_core_directory).and_return(delivering_promise)
       instance.stub(:promise_extract_droplet).and_return(delivering_promise)
       instance.stub(:promise_prepare_start_script).and_return(delivering_promise)
       instance.stub(:promise_exec_hook_script).with('before_start').and_return(delivering_promise)
@@ -739,6 +740,41 @@ describe Dea::Instance do
 
       it 'can fail by run failing' do
         msg = 'droplet extraction failure'
+        instance.container.stub(:run_script) do |*_|
+          raise RuntimeError.new(msg)
+        end
+
+        expect_start.to raise_error(msg)
+      end
+    end
+
+    describe 'setting up core directory' do
+      before do
+        bootstrap.stub(:config).and_return('kernel' => {'core_directory' => '/var/vcap/sys/cores'})
+        instance.unstub(:promise_setup_kernel_core_directory)
+      end
+
+      it 'should create the core dir' do
+        instance.container.stub(:run_script) do |_, script|
+          script.should =~ %r{mkdir -p /var/vcap/sys/cores}
+        end
+
+        expect_start.to_not raise_error
+        instance.exit_description.should be_empty
+      end
+
+      it 'should chown the core dir' do
+        instance.container.stub(:run_script) do |_, script|
+          script.should =~ %r{chown vcap:vcap /var/vcap/sys/cores}
+        end
+
+        expect_start.to_not raise_error
+        instance.exit_description.should be_empty
+      end
+
+      it 'should fail by run failing' do
+        msg = 'core directory setup failure'
+
         instance.container.stub(:run_script) do |*_|
           raise RuntimeError.new(msg)
         end


### PR DESCRIPTION
The issue is related to the one opened in cf-release project.
https://github.com/cloudfoundry/cf-release/pull/400

The aim for the changes is to create the configured kernel core directory, currently, it was only created in the application starting phase, not considered of the staging phase.
