### PR TITLE
When logging error to loggregator, use emit_error in place of emit

### DIFF
--- a/lib/dea/starting/instance.rb
+++ b/lib/dea/starting/instance.rb
@@ -719,7 +719,7 @@ module Dea
           hc.callback { p.deliver(true) }
 
           hc.errback do
-            Dea::Loggregator.emit(application_id, "Instance (index #{instance_index}) failed to start accepting connections")
+            Dea::Loggregator.emit_error(application_id, "Instance (index #{instance_index}) failed to start accepting connections")
             p.deliver(false)
           end
 

--- a/spec/unit/starting/instance_spec.rb
+++ b/spec/unit/starting/instance_spec.rb
@@ -475,7 +475,7 @@ describe Dea::Instance do
         execute_health_check do
           deferrable.fail
         end
-        expect(@emitter.messages[application_id][0]).to eql('Instance (index 2) failed to start accepting connections')
+        expect(@emitter.error_messages[application_id][0]).to eql('Instance (index 2) failed to start accepting connections')
       end
     end
 


### PR DESCRIPTION
In /lib/dea/starting/instance.rb:promise_port_open(port),  error message is sent to loggregator using emit().  Change it to use emit_error()
