### PR TITLE
Add apt-get update to Vagrantfile for DEA tests to run properly

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,7 @@ Vagrant.configure("2") do |config|
   end
 
   # For Nokogiri
+  config.vm.provision "shell", inline: "sudo apt-get -y update"
   config.vm.provision "shell", inline: "sudo apt-get -q -y install libxslt-dev libxml2-dev"
   config.vm.provision "shell", inline: "sudo apt-get -q -y install libcurl4-gnutls-dev"
 end


### PR DESCRIPTION
apt-get update needs to run before attempting to install the packages for Nokogiri as 404 errors are found during apt-get install. 
