### PR TITLE
Remove stdout and stderr logs from app startup.

### DIFF
--- a/lib/dea/starting/startup_script_generator.rb
+++ b/lib/dea/starting/startup_script_generator.rb
@@ -20,7 +20,7 @@ module Dea
     START_SCRIPT = strip_heredoc(<<-BASH).freeze
       DROPLET_BASE_DIR=$PWD
       cd app
-      (%s) > >(tee $DROPLET_BASE_DIR/logs/stdout.log) 2> >(tee $DROPLET_BASE_DIR/logs/stderr.log >&2) &
+      (%s) &
       STARTED=$!
       echo "$STARTED" >> $DROPLET_BASE_DIR/run.pid
 


### PR DESCRIPTION
This is the PR to fix https://github.com/cloudfoundry/dea_ng/issues/115.

It didn't appear any tests referenced this functionality.
