### PR TITLE
Make DEA to be conscious belonging zone and advertise it

### DIFF
--- a/lib/dea/bootstrap.rb
+++ b/lib/dea/bootstrap.rb
@@ -93,6 +93,7 @@ module Dea
     def setup_varz
       VCAP::Component.varz.synchronize do
         VCAP::Component.varz[:stacks] = config["stacks"]
+        VCAP::Component.varz[:zone] = config["placement_properties"]["zone"]
       end
 
       EM.add_periodic_timer(DEFAULT_HEARTBEAT_INTERVAL) do

--- a/lib/dea/protocol.rb
+++ b/lib/dea/protocol.rb
@@ -45,6 +45,7 @@ module Dea::Protocol::V1
       end
 
       if request["include_stats"] && instance.running?
+        zone = bootstrap.config["placement_properties"]["zone"]
         response["stats"] = {
           "name"       => instance.application_name,
           "uris"       => instance.application_uris,
@@ -54,6 +55,7 @@ module Dea::Protocol::V1
           "mem_quota"  => instance.memory_limit_in_bytes,
           "disk_quota" => instance.disk_limit_in_bytes,
           "fds_quota"  => instance.file_descriptor_limit,
+          "zone" => zone,
           "usage"      => {
             "time" => Time.now.to_s,
             "cpu"  => instance.computed_pcpu,

--- a/lib/dea/responders/staging_locator.rb
+++ b/lib/dea/responders/staging_locator.rb
@@ -30,11 +30,18 @@ module Dea::Responders
       # Currently we are not tracking memory used by
       # staging task, therefore, available_memory
       # is not accurate since it only account for running apps.
+      placement_properties_hash = if config["placement_properties"]["zone"]
+        {"zone" => config["placement_properties"]["zone"] }
+      else
+        {}
+      end
       nats.publish("staging.advertise", {
         "id" => dea_id,
         "stacks" => config["stacks"],
         "available_memory" => resource_manager.remaining_memory,
         "available_disk" => resource_manager.remaining_disk,
+        "app_id_to_count" => resource_manager.app_id_to_count,
+        "placement_properties" => placement_properties_hash,
       })
     rescue => e
       logger.error("staging_locator.advertise", error: e, backtrace: e.backtrace)

--- a/spec/unit/bootstrap_spec.rb
+++ b/spec/unit/bootstrap_spec.rb
@@ -225,6 +225,34 @@ describe Dea::Bootstrap do
 
       VCAP::Component.varz[:stacks].should == ["Linux"]
     end
+
+    describe "add zone to varz" do
+      shared_examples_for 'a varz response' do |subject|
+        it "#{subject}" do
+          bootstrap.stub(:nats).and_return(nats_client_mock)
+
+          # stubbing this to avoid a runtime exception
+          EM.stub(:add_periodic_timer)
+
+          bootstrap.setup_varz
+
+          VCAP::Component.varz[:zone].should == expected
+        end
+      end
+
+      context "when config ['placement_properties']['zone'] = zoneX" do
+        it_should_behave_like "a varz response", "should zone = zoneX" do
+          let(:expected) { "zoneX" }
+          before { @config["placement_properties"] = { "zone" => "zoneX" } }
+        end
+      end
+
+      context "when does not config placement properties" do
+        it_should_behave_like "a varz response", "should zone = default" do
+          let(:expected) { "default" }
+        end
+      end
+    end
   end
 
   describe "#periodic_varz_update" do


### PR DESCRIPTION
To extend the 'zone' functionality, DEA is made to
- be conscious of which zone it belongs to, and
- advertise the zone info via message bus / varz

This is a part of a set of pull requests that adds more intelligent / convenient featurenos to 'zone' functionality.
Details of the features are given in the pull request to cloud_controller_ng [1]. Here we just give a brief description.

[1] https://github.com/cloudfoundry/cloud_controller_ng/pull/269

The set of pull requests:
- introduces finer logic to distribute instances of an app
- adds "zone validation" to enhance manageability
- configures "main zone", which is the prior place where the first instance of an app will be deployed
- enables a user to specify a single zone to deploy (all instances of) an app

The commit in this pull request provides a basis of the features above.
