### PR TITLE
Added Warden container IP to snapshot

### DIFF
--- a/lib/container/container.rb
+++ b/lib/container/container.rb
@@ -18,7 +18,7 @@ class Container
   }
 
   attr_accessor :handle
-  attr_reader :path, :host_ip, :network_ports
+  attr_reader :path, :host_ip, :container_ip, :network_ports
 
   def initialize(client_provider)
     @client_provider = client_provider
@@ -34,6 +34,7 @@ class Container
     raise RuntimeError, 'container path is not available' unless response.container_path
     @path = response.container_path
     @host_ip = response.host_ip
+    @container_ip = response.container_ip
 
     response
   end

--- a/lib/dea/starting/instance.rb
+++ b/lib/dea/starting/instance.rb
@@ -856,6 +856,7 @@ module Dea
         'warden_job_id' => attributes['warden_job_id'],
         'warden_container_path' => container.path,
         'warden_host_ip' => container.host_ip,
+        'warden_container_ip' => container.container_ip,
         'instance_host_port' => container.network_ports['host_port'],
         'instance_container_port' => container.network_ports['container_port'],
 

--- a/spec/unit/bootstrap/snapshot_spec.rb
+++ b/spec/unit/bootstrap/snapshot_spec.rb
@@ -108,6 +108,7 @@ describe Dea::Snapshot do
       it 'has extra keys for debugging purpose' do
         expected_keys = %w(
           warden_host_ip
+          warden_container_ip
           instance_host_port
           instance_id
         )

--- a/spec/unit/container/container_spec.rb
+++ b/spec/unit/container/container_spec.rb
@@ -74,7 +74,12 @@ describe Container do
   describe '#update_path_and_ip' do
     let(:container_path) { '/container/path' }
     let(:container_host_ip) { '1.7.goodip' }
-    let(:info_response) { Warden::Protocol::InfoResponse.new(:container_path => container_path, :host_ip => container_host_ip) }
+    let(:container_ip) { '1.8.betterip' }
+    let(:info_response) { Warden::Protocol::InfoResponse.new(
+        :container_path => container_path,
+        :host_ip => container_host_ip,
+        :container_ip => container_ip
+    ) }
 
     it "makes warden InfoRequest, then updates and returns the container's path" do
       container.should_receive(:call).and_return do |name, request|
@@ -86,6 +91,7 @@ describe Container do
       container.update_path_and_ip
       expect(container.path).to eq(container_path)
       expect(container.host_ip).to eq(container_host_ip)
+      expect(container.container_ip).to eq(container_ip)
     end
 
     context 'when InfoRequest does not return a container_path in the response' do


### PR DESCRIPTION
The host IP in db/instances.json is not very useful because any packets sent from the application get translated to the container IP as soon as the packet leaves the container.

For auditing purposes, we need to log when TCP connections are made to certain network zones. This is simple to do using iptables. The problem is correlating which application sent the packet. This can easily be accomplished using db/instances.json if the instances.json had the container IP.
