### PR TITLE
Add http/https proxy system environment variables for both staging and i...

### DIFF
--- a/lib/dea/config.rb
+++ b/lib/dea/config.rb
@@ -101,7 +101,10 @@ module Dea
             "memory_to_cpu_share_ratio" => Integer,
             "max_cpu_share_limit" => Integer,
             "min_cpu_share_limit" => Integer,
-            "disk_inode_limit" => Integer
+            "disk_inode_limit" => Integer,
+            optional("http_proxy") => String,
+            optional("https_proxy") => String,
+            optional("no_proxy") => String
           },
 
           optional("staging") => {
@@ -110,7 +113,10 @@ module Dea
             optional("environment") => Hash,
             optional("memory_limit_mb") => Integer,
             optional("disk_limit_mb") => Integer,
-            optional("cpu_limit_shares") => Integer
+            optional("cpu_limit_shares") => Integer,
+            optional("http_proxy") => String,
+            optional("https_proxy") => String,
+            optional("no_proxy") => String
           }
         }
       end

--- a/lib/dea/staging/env.rb
+++ b/lib/dea/staging/env.rb
@@ -14,8 +14,11 @@ module Dea
         [
           ["BUILDPACK_CACHE", staging_task.staging_config["environment"]["BUILDPACK_CACHE"]],
           ["STAGING_TIMEOUT", staging_task.staging_timeout],
-          ["MEMORY_LIMIT", "#{message.mem_limit}m"]
-        ]
+          ["MEMORY_LIMIT", "#{message.mem_limit}m"],
+          ["http_proxy", staging_task.staging_config["http_proxy"]],
+          ["https_proxy", staging_task.staging_config["https_proxy"]],
+          ["no_proxy", staging_task.staging_config["no_proxy"]]
+        ].delete_if {|item| item[1].nil? }
       end
 
       def vcap_application

--- a/lib/dea/starting/env.rb
+++ b/lib/dea/starting/env.rb
@@ -16,8 +16,11 @@ module Dea
           ["TMPDIR", "$PWD/tmp"],
           ["VCAP_APP_HOST", "0.0.0.0"],
           ["VCAP_APP_PORT", @instance.instance_container_port],
-          ["PORT", "$VCAP_APP_PORT"]
-        ]
+          ["PORT", "$VCAP_APP_PORT"],
+          ["http_proxy", @instance.config["instance"]["http_proxy"]],
+          ["https_proxy", @instance.config["instance"]["https_proxy"]],
+          ["no_proxy", @instance.config["instance"]["no_proxy"]]
+        ].delete_if {|item| item[1].nil? }
       end
 
       def vcap_application

--- a/spec/unit/env_spec.rb
+++ b/spec/unit/env_spec.rb
@@ -44,7 +44,8 @@ describe Dea::Env do
 
   let(:instance) do
     attributes = {"instance_id" => VCAP.secure_uuid}
-    double(:instance, attributes: attributes, instance_container_port: 4567, state_starting_timestamp: Time.now.to_f)
+    config = {"instance" => ""}
+    double(:instance, attributes: attributes, instance_container_port: 4567, state_starting_timestamp: Time.now.to_f, config: config)
   end
 
   let(:start_message) do

--- a/spec/unit/staging/env_spec.rb
+++ b/spec/unit/staging/env_spec.rb
@@ -22,6 +22,27 @@ module Dea::Staging
                                                       %w(MEMORY_LIMIT fake_mem_limitm),
                                                     ])
       end
+
+      context "when setting proxy" do
+          let(:staging_config) {
+            {
+                "http_proxy" => "http://user:password@1.2.3.4:8080/",
+                "https_proxy" => "https://user:password@1.2.3.4:8080/",
+                "no_proxy" => "localhost,127.0.0.1",
+                "environment" => { "BUILDPACK_CACHE" => "fake_buildpack_cache" }
+            }
+          }
+          it "can get the proxy correctly" do
+            expect(system_environment_variables).to eql([
+                                                            %w(BUILDPACK_CACHE fake_buildpack_cache),
+                                                            %w(STAGING_TIMEOUT fake_timeout),
+                                                            %w(MEMORY_LIMIT fake_mem_limitm),
+                                                            %w(http_proxy http://user:password@1.2.3.4:8080/) ,
+                                                            %w(https_proxy https://user:password@1.2.3.4:8080/),
+                                                            %w(no_proxy localhost,127.0.0.1),
+                                                        ])
+          end
+      end
     end
 
     describe "vcap_application" do


### PR DESCRIPTION
...nstance container

Based on the [discussion](https://groups.google.com/a/cloudfoundry.org/forum/#!mydiscussions/vcap-dev/RTfJ_-WfwDI) in Google Groups, add system environment variables support for http/https proxy for staging and instance container.

Example configuration is as follows

```
staging:
  enabled: true
  environment:
    PATH: /usr/local/ruby/bin
    BUILDPACK_CACHE: /var/vcap/packages/buildpack_cache
  memory_limit_mb: 1024
  disk_limit_mb: 2048
  disk_inode_limit: 200000
  cpu_limit_shares: 512
  max_staging_duration: 900 # 15 minutes
  http_proxy: http_proxy_url
  https_proxy: http_proxy_url
  no_proxy: localhost,127.0.0.1

instance:
  disk_inode_limit: 200000
  memory_to_cpu_share_ratio: 8
  max_cpu_share_limit: 256
  min_cpu_share_limit: 1
  http_proxy: http_proxy_url
  https_proxy: https_proxy_url
  no_proxy: localhost,127.0.0.1
```
