### PR TITLE
Log the staging message at debug level to prevent logging credentials.

### DIFF
--- a/lib/dea/staging/staging_task.rb
+++ b/lib/dea/staging/staging_task.rb
@@ -492,7 +492,7 @@ module Dea
     end
 
     def snapshot_attributes
-      logger.info('snapshot_attributes', properties: staging_message.properties)
+      logger.debug('snapshot_attributes', properties: staging_message.properties)
       {
         'staging_message' => staging_message.to_hash,
         'warden_container_path' => container.path,


### PR DESCRIPTION
The staging message contains service credentials and therefor should be logged at debug level to keep passwords and/or other sensitive data from leaking into the logs in production environments.
