### PR TITLE
Make writing env to disk configurable.

### DIFF
--- a/config/dea.yml
+++ b/config/dea.yml
@@ -46,6 +46,7 @@ instance:
   memory_to_cpu_share_ratio: 8
   max_cpu_share_limit: 256
   min_cpu_share_limit: 1
+  persist_env: true
 
 dea_ruby: /usr/bin/ruby
 

--- a/lib/dea/config.rb
+++ b/lib/dea/config.rb
@@ -22,6 +22,7 @@ module Dea
         "max_cpu_share_limit" => 256,
         "min_cpu_share_limit" => 1,
         "disk_inode_limit" => DEFAULT_INSTANCE_DISK_INODE_LIMIT,
+        "persist_env" => true
       },
       "staging" => {
         "cpu_limit_shares" => 512,
@@ -101,7 +102,8 @@ module Dea
             "memory_to_cpu_share_ratio" => Integer,
             "max_cpu_share_limit" => Integer,
             "min_cpu_share_limit" => Integer,
-            "disk_inode_limit" => Integer
+            "disk_inode_limit" => Integer,
+            "persist_env" => bool
           },
 
           optional("staging") => {

--- a/lib/dea/starting/instance.rb
+++ b/lib/dea/starting/instance.rb
@@ -427,7 +427,8 @@ module Dea
             Dea::StartupScriptGenerator.new(
               command,
               env.exported_user_environment_variables,
-              env.exported_system_environment_variables
+              env.exported_system_environment_variables,
+              config['instance']['persist_env']
             ).generate
         else
           start_script = env.exported_environment_variables + "./startup;\nexit"

--- a/lib/dea/starting/startup_script_generator.rb
+++ b/lib/dea/starting/startup_script_generator.rb
@@ -27,10 +27,11 @@ module Dea
       wait $STARTED
     BASH
 
-    def initialize(start_command, user_envs, system_envs)
+    def initialize(start_command, user_envs, system_envs, log_env)
       @start_command = start_command
       @user_envs = user_envs
       @system_envs = system_envs
+      @log_env = log_env
     end
 
     def generate
@@ -39,7 +40,9 @@ module Dea
       script << @system_envs
       script << EXPORT_BUILDPACK_ENV_VARIABLES_SCRIPT
       script << @user_envs
-      script << "env > logs/env.log"
+      if @log_env
+        script << "env > logs/env.log"
+      end
       script << START_SCRIPT % @start_command
       script.join("\n")
     end

--- a/spec/unit/starting/instance_spec.rb
+++ b/spec/unit/starting/instance_spec.rb
@@ -906,7 +906,8 @@ describe Dea::Instance do
           expect(Dea::StartupScriptGenerator).to receive(:new).with(
                                                      'fake_start_command.sh',
                                                      env.exported_user_environment_variables,
-                                                     env.exported_system_environment_variables
+                                                     env.exported_system_environment_variables,
+                                                     true
                                                  ).and_return(generator)
 
           instance.promise_start.resolve

--- a/spec/unit/starting/startup_script_generator_spec.rb
+++ b/spec/unit/starting/startup_script_generator_spec.rb
@@ -7,7 +7,7 @@ describe Dea::StartupScriptGenerator do
   let(:used_buildpack) { '' }
   let(:start_command) { 'go_nuts' }
 
-  let(:generator) { Dea::StartupScriptGenerator.new(start_command, user_envs, system_envs) }
+  let(:generator) { Dea::StartupScriptGenerator.new(start_command, user_envs, system_envs, true) }
 
   describe "#generate" do
     subject(:script) { generator.generate }
@@ -47,6 +47,15 @@ describe Dea::StartupScriptGenerator do
       it "print env to a log file after user envs" do
         script.should include "env > logs/env.log"
         script.should match /usrval1.*env\.log/m
+      end
+    end
+
+    describe "disable env log" do
+      let(:generator) { Dea::StartupScriptGenerator.new(start_command, user_envs, system_envs, false) }
+      subject(:script) { generator.generate }
+
+      it "does not generate env log" do
+        script.should_not include "env > logs/env.log"
       end
     end
 


### PR DESCRIPTION
We have strict security requirements that prevent us from writing clear text passwords to disk. Unfortunately the DEA does this when it write the environment out to logs/env.log. We would like to make the persisting of  the environment configurable so that we can disable it.
