### PR TITLE
Change the STARTING state to CRASHED when loading instance-snapshot

### DIFF
--- a/lib/dea/snapshot.rb
+++ b/lib/dea/snapshot.rb
@@ -65,7 +65,12 @@ module Dea
 
           # Enter instance state via "RESUMING" to trigger the right transitions
           instance.state = Instance::State::RESUMING
-          instance.state = instance_state
+
+          if instance_state == Instance::State::STARTING
+             instance.state = Instance::State::CRASHED
+          else
+             instance.state = instance_state
+          end
         end
 
         logger.debug("Loading snapshot took: %.3fs" % [Time.now - start])

--- a/lib/dea/starting/instance_manager.rb
+++ b/lib/dea/starting/instance_manager.rb
@@ -24,6 +24,7 @@ module Dea
 
       instance.on(Instance::Entering.new(:crashed)) do
         send_crashed_message(instance)
+        bootstrap.snapshot.save
       end
 
       instance.on(Instance::Entering.new(:running)) do
@@ -34,7 +35,6 @@ module Dea
 
       instance.on(Instance::Transition.new(:running, :crashed)) do
          bootstrap.router_client.unregister_instance(instance)
-         bootstrap.snapshot.save
        end
 
       instance.on(Instance::Entering.new(:stopping)) do

--- a/spec/unit/starting/instance_manager_spec.rb
+++ b/spec/unit/starting/instance_manager_spec.rb
@@ -111,6 +111,11 @@ describe Dea::InstanceManager do
                 expect(@published_messages["droplet.exited"].first["reason"]).to eq "CRASHED"
                 expect(@published_messages["droplet.exited"].first["instance"]).to eq instance.instance_id
               end
+
+              it "saves the snapshot" do
+                bootstrap.snapshot.should_receive(:save)
+                subject
+              end
             end
 
             context "and it transitions to stopped" do
@@ -167,6 +172,11 @@ describe Dea::InstanceManager do
                 expect(@published_messages["droplet.exited"]).to have(1).item
                 expect(@published_messages["droplet.exited"].first["reason"]).to eq "CRASHED"
                 expect(@published_messages["droplet.exited"].first["instance"]).to eq instance.instance_id
+              end
+
+              it "saves the snapshot" do
+                bootstrap.snapshot.should_receive(:save)
+                subject
               end
             end
           end


### PR DESCRIPTION
The problem is: After restarting DEA, the instance loaded from snapshot stays in the STARTING state, so can't be accessed .

The reason is, DEA simply creates the instance from snapshot and register, then the heartbeat is reported to the HM with current state. So if the snapshot is in STARTING state, HM will regard it as normal, and doesn't notify CC to send the command of starting up the instance. Then, the instance can be accessed.

So should change the state to CRASHED to trigger the correct starting up process.