### PR TITLE
Escape env values rather than simply quote them.

### DIFF
--- a/lib/dea/env/exporter.rb
+++ b/lib/dea/env/exporter.rb
@@ -1,9 +1,11 @@
+require 'shellwords'
+
 module Dea
   class Env
     class Exporter < Struct.new(:variables)
       def export
         variables.map do |(key, value)|
-          %Q{export %s="%s";\n} % [key, value.to_s.gsub('"', '\"')]
+          %Q{export %s=%s;\n} % [key, Shellwords.shellescape(value.to_s)]
         end.join
       end
     end

--- a/spec/unit/env/exporter_spec.rb
+++ b/spec/unit/env/exporter_spec.rb
@@ -10,7 +10,7 @@ module Dea
         let(:variables) { [[:a, 1]] }
 
         it "exports the variables" do
-          expect(env_exporter.export).to eql(%Q{export a="1";\n})
+          expect(env_exporter.export).to eql(%Q{export a=1;\n})
         end
       end
 
@@ -18,7 +18,7 @@ module Dea
         let(:variables) { [["a", 1], ["b", 2]] }
 
         it "exports the variables" do
-          expect(env_exporter.export).to eql(%Q{export a="1";\nexport b="2";\n})
+          expect(env_exporter.export).to eql(%Q{export a=1;\nexport b=2;\n})
         end
       end
 
@@ -26,7 +26,7 @@ module Dea
         let(:variables) { [["a", %Q{"1'}]] }
 
         it "exports the variables" do
-          expect(env_exporter.export).to eql(%Q{export a="\\"1'";\n})
+          expect(env_exporter.export).to eql(%Q{export a=\\"1\\';\n})
         end
       end
 
@@ -34,7 +34,7 @@ module Dea
         let(:variables) { [[:a, :b]] }
 
         it "exports the variables" do
-          expect(env_exporter.export).to eql(%Q{export a="b";\n})
+          expect(env_exporter.export).to eql(%Q{export a=b;\n})
         end
       end
 
@@ -42,7 +42,7 @@ module Dea
         let(:variables) { [[:a, "one two"]] }
 
         it "exports the variables" do
-          expect(env_exporter.export).to eql(%Q{export a="one two";\n})
+          expect(env_exporter.export).to eql(%Q{export a=one\\ two;\n})
         end
       end
 
@@ -50,7 +50,23 @@ module Dea
         let(:variables) { [[:a, "one=two"]] }
 
         it "exports the variables" do
-          expect(env_exporter.export).to eql(%Q{export a="one=two";\n})
+          expect(env_exporter.export).to eql(%Q{export a=one\\=two;\n})
+        end
+      end
+
+      context "with $ in values" do
+        let(:variables) { [[:a, "one$two"]] }
+
+        it "exports the variables" do
+          expect(env_exporter.export).to eql(%Q{export a=one\\$two;\n})
+        end
+      end
+
+      context "with ` in values" do
+        let(:variables) { [[:a, "one`two"]] }
+
+        it "exports the variables" do
+          expect(env_exporter.export).to eql(%Q{export a=one\\`two;\n})
         end
       end
 
@@ -60,9 +76,9 @@ module Dea
         context "when evaluated by bash" do
           let(:evaluated_env) { `#{env_exporter.export} env` }
 
-          it "substitutes the reference" do
+          it "does NOT substitute the reference" do
             expect(evaluated_env).to include("x=bar")
-            expect(evaluated_env).to include("foo=bar")
+            expect(evaluated_env).to include("foo=$x")
           end
         end
       end

--- a/spec/unit/staging/staging_task_spec.rb
+++ b/spec/unit/staging/staging_task_spec.rb
@@ -89,11 +89,11 @@ describe Dea::StagingTask do
     describe 'assembles staging command correctly' do
       it 'calls the container#spawn with the staging command' do
         expect(staging_task.container).to receive(:spawn) do |cmd|
-          expect(cmd).to include 'export FOO="BAR";'
-          expect(cmd).to include 'export BUILDPACK_CACHE="buildpack_cache_url";'
-          expect(cmd).to include 'export STAGING_TIMEOUT="900.0";'
-          expect(cmd).to include 'export MEMORY_LIMIT="512m";' # the user assiged 512 should overwrite the system 256
-          expect(cmd).to include 'export VCAP_SERVICES="'
+          expect(cmd).to include 'export FOO=BAR;'
+          expect(cmd).to include 'export BUILDPACK_CACHE=buildpack_cache_url;'
+          expect(cmd).to include 'export STAGING_TIMEOUT=900.0;'
+          expect(cmd).to include 'export MEMORY_LIMIT=512m;' # the user assiged 512 should overwrite the system 256
+          expect(cmd).to include 'export VCAP_SERVICES='
 
           expect(cmd).to match %r{.*/bin/run .*/plugin_config | tee -a}
 
@@ -111,7 +111,7 @@ describe Dea::StagingTask do
 
         it 'copes with spaces' do
           staging_task.container.should_receive(:spawn) do |cmd|
-            expect(cmd).to include('export PATH="x y z";')
+            expect(cmd).to include('export PATH=x\\ y\\ z;')
 
             spawn_response
           end
@@ -124,7 +124,7 @@ describe Dea::StagingTask do
 
         it 'copes with quotes' do
           staging_task.container.should_receive(:spawn) do |cmd|
-            expect(cmd).to include(%Q{export FOO="z'y\\"d";})
+            expect(cmd).to include(%Q{export FOO=z\\'y\\"d;})
           end.and_return(spawn_response)
 
           with_event_machine do
@@ -135,7 +135,7 @@ describe Dea::StagingTask do
 
         it 'copes with blank' do
           staging_task.container.should_receive(:spawn) do |cmd|
-            expect(cmd).to include('export BAR="";')
+            expect(cmd).to include("export BAR='';")
 
             spawn_response
           end
@@ -148,7 +148,7 @@ describe Dea::StagingTask do
 
         it 'copes with equal sign' do
           staging_task.container.should_receive(:spawn) do |cmd|
-            expect(cmd).to include('export BAZ="foo=baz";')
+            expect(cmd).to include('export BAZ=foo\\=baz;')
           end.and_return(spawn_response)
 
           with_event_machine do


### PR DESCRIPTION
This implements a fix for #144.