### PR TITLE
Add warden_handle method to staging task

### DIFF
--- a/lib/dea/staging/staging_task.rb
+++ b/lib/dea/staging/staging_task.rb
@@ -512,6 +512,10 @@ module Dea
       }
     end
 
+    def warden_handle
+      container.handle
+    end
+
     private
 
     def staging_command

--- a/spec/unit/staging/staging_task_spec.rb
+++ b/spec/unit/staging/staging_task_spec.rb
@@ -1282,6 +1282,13 @@ YAML
     end
   end
 
+  describe '#warden_handle' do
+    it 'gets the warden container handle' do
+      expect(staging_task.container).to receive(:handle).and_return('container_handle')
+      expect(staging_task.warden_handle).to eq('container_handle')
+    end
+  end
+
   def normalize_whitespace(script)
     script.gsub(/\s+/, ' ')
   end


### PR DESCRIPTION
The method is missing but called on the orphan container cleanup path.