### PR TITLE
Enable staging and running bandwidth config

### DIFF
--- a/lib/container/container.rb
+++ b/lib/container/container.rb
@@ -121,6 +121,7 @@ class Container
       limit_cpu(params[:limit_cpu])
       limit_disk(byte: params[:byte], inode: params[:inode])
       limit_memory(params[:limit_memory])
+      limit_bandwidth(params[:limit_bandwidth]) if params[:limit_bandwidth]
       setup_inbound_network if params[:setup_inbound_network]
       setup_egress_rules(params[:egress_rules])
     end
@@ -220,6 +221,11 @@ class Container
 
   def limit_memory(bytes)
     call(:app, ::Warden::Protocol::LimitMemoryRequest.new(handle: handle, limit_in_bytes: bytes))
+  end
+
+  def limit_bandwidth(params)
+    request_params = { handle: handle, rate: params[:rate], burst: params[:burst] }
+    call(:app, ::Warden::Protocol::LimitBandwidthRequest.new(request_params))
   end
 
   private

--- a/lib/dea/config.rb
+++ b/lib/dea/config.rb
@@ -116,7 +116,11 @@ module Dea
             "memory_to_cpu_share_ratio" => Integer,
             "max_cpu_share_limit" => Integer,
             "min_cpu_share_limit" => Integer,
-            "disk_inode_limit" => Integer
+            "disk_inode_limit" => Integer,
+            optional("bandwidth_limit") => {
+              "rate" => Integer,
+              "burst" => Integer,
+            },
           },
 
           optional("staging") => {
@@ -125,7 +129,11 @@ module Dea
             optional("environment") => Hash,
             optional("memory_limit_mb") => Integer,
             optional("disk_limit_mb") => Integer,
-            optional("cpu_limit_shares") => Integer
+            optional("cpu_limit_shares") => Integer,
+            optional("bandwidth_limit") => {
+              "rate" => Integer,
+              "burst" => Integer,
+            },
           }
         }
       end
@@ -189,6 +197,14 @@ module Dea
 
     def instance_disk_inode_limit
       @config.fetch("instance", {}).fetch("disk_inode_limit", DEFAULT_INSTANCE_DISK_INODE_LIMIT)
+    end
+
+    def staging_bandwidth_limit
+      @config.fetch("staging", {})["bandwidth_limit"]
+    end
+
+    def instance_bandwidth_limit
+      @config.fetch("instance", {})["bandwidth_limit"]
     end
 
     def rootfs_path(stack_name)

--- a/lib/dea/staging/staging_task.rb
+++ b/lib/dea/staging/staging_task.rb
@@ -539,6 +539,13 @@ module Dea
       services.map { |svc_hash| svc_hash['syslog_drain_url'] }.compact
     end
 
+    def bandwidth_limit
+      limit = config.staging_bandwidth_limit
+      return nil unless limit
+
+      { rate: limit['rate'], burst: limit['burst'] }
+    end
+
     def resolve_staging_setup
       workspace.prepare(buildpack_manager)
       with_network = false
@@ -556,6 +563,7 @@ module Dea
         setup_inbound_network: with_network,
         egress_rules: staging_message.egress_rules,
         rootfs: rootfs,
+        limit_bandwidth: bandwidth_limit,
       )
       promises = [promise_app_download]
       promises << promise_buildpack_cache_download if staging_message.buildpack_cache_download_uri

--- a/lib/dea/starting/instance.rb
+++ b/lib/dea/starting/instance.rb
@@ -548,7 +548,9 @@ module Dea
           limit_memory: memory_limit_in_bytes,
           setup_inbound_network: with_network,
           egress_rules: egress_network_rules,
-          rootfs: rootfs)
+          rootfs: rootfs,
+          limit_bandwidth: bandwidth_limit,
+        )
 
         attributes['warden_handle'] = container.handle
 
@@ -935,6 +937,13 @@ module Dea
 
     def default_health_check_timeout
       config['default_health_check_timeout']
+    end
+
+    def bandwidth_limit
+      limit = config.instance_bandwidth_limit
+      return nil unless limit
+
+      { rate: limit['rate'], burst: limit['burst'] }
     end
 
     def logger

--- a/spec/support/em_helpers.rb
+++ b/spec/support/em_helpers.rb
@@ -7,7 +7,7 @@ module Helpers
     raise "no block given" unless block_given?
     timeout = options[:timeout] ||= 10
 
-    ::EM.epoll
+    ::EM.epoll if ::EM.epoll?
 
     ::EM.run do
       quantum = 0.005

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -59,6 +59,25 @@ module Dea
       end
     end
 
+    describe '#rootfs_path' do
+      let(:stacks) { [{ 'name' => 'my-stack', 'package_path' => '/path/to/rootfs' }] }
+      let(:config_hash) { { 'stacks' => stacks } }
+
+      context 'when the stack name exists in the config' do
+        let(:stack_name) { 'my-stack' }
+
+        it 'returns the associated rootfs path' do
+          expect(config.rootfs_path(stack_name)).to eq('/path/to/rootfs')
+        end
+      end
+
+      context 'when the stack name does not exist in the config' do
+        it 'returns nil' do
+          expect(config.rootfs_path('not-exist')).to be_nil
+        end
+      end
+    end
+
     describe "#staging_disk_inode_limit" do
       context "when the config hash has no key for staging disk inode limit" do
         let(:config_hash) { { "staging" => { } } }
@@ -81,31 +100,6 @@ module Dea
       end
     end
 
-    describe '#rootfs_path' do
-      let(:stacks) do
-        [
-          {
-            'name' => 'my-stack',
-            'package_path' => '/path/to/rootfs',
-          }
-        ]
-      end
-      let(:config_hash) { { 'stacks' => stacks } }
-
-      context 'when the stack name exists in the config' do
-        let(:stack_name) { 'my-stack' }
-        it 'returns the associated rootfs path' do
-          expect(config.rootfs_path(stack_name)).to eq('/path/to/rootfs')
-        end
-      end
-
-      context 'when the stack name does not exist in the config' do
-        it 'raises an error' do
-          expect(config.rootfs_path('not-exist')).to be_nil
-        end
-      end
-    end
-
     describe "#instance_disk_inode_limit" do
       context "when the config hash has no key for instance disk inode limit" do
         let(:config_hash) { { "instance" => { } } }
@@ -124,6 +118,44 @@ module Dea
 
         it "provides a reasonable default" do
           expect(config.instance_disk_inode_limit).to eq(disk_inode_limit)
+        end
+      end
+    end
+
+    describe "#staging_bandwidth_limit" do
+      context "when the config hash does not have a staging bandwidth limit" do
+        let(:config_hash) { { "staging" => {} } }
+
+        it "returns nil" do
+          expect(config.staging_bandwidth_limit).to be_nil
+        end
+      end
+
+      context "when the config hash has a staging_bandwidth_limit defined" do
+        let(:bandwidth) { { "rate" => 1000000, "burst" => 2000000 } }
+        let(:config_hash) { { "staging" => { "bandwidth_limit" => bandwidth } } }
+
+        it "returns the staging bandwidth limit" do
+          expect(config.staging_bandwidth_limit).to eq(bandwidth)
+        end
+      end
+    end
+
+    describe "#instance_bandwidth_limit" do
+      context "when the config hash does not have an instance bandwidth limit" do
+        let(:config_hash) { { "instance" => {} } }
+
+        it "returns nil" do
+          expect(config.instance_bandwidth_limit).to be_nil
+        end
+      end
+
+      context "when the config hash has an instance_bandwidth_limit defined" do
+        let(:bandwidth) { { "rate" => 1000000, "burst" => 2000000 } }
+        let(:config_hash) { { "instance" => { "bandwidth_limit" => bandwidth } } }
+
+        it "returns the instance bandwidth limit" do
+          expect(config.instance_bandwidth_limit).to eq(bandwidth)
         end
       end
     end

--- a/spec/unit/staging/staging_task_spec.rb
+++ b/spec/unit/staging/staging_task_spec.rb
@@ -42,7 +42,8 @@ describe Dea::StagingTask do
         'memory_limit_mb' => memory_limit_mb,
         'disk_limit_mb' => disk_limit_mb,
         'disk_inode_limit' => disk_inode_limit,
-        'max_staging_duration' => max_staging_duration
+        'max_staging_duration' => max_staging_duration,
+        'bandwidth_limit' => { 'rate' => 20_000_000, 'burst' => 100_000_000 },
       },
     }
   end
@@ -668,6 +669,7 @@ YAML
 
     it 'performs staging setup operations in correct order' do
       with_network = false
+      expected_bandwidth = { rate: 20_000_000, burst: 100_000_000 }
       staging_task.workspace.should_receive(:prepare).ordered
       staging_task.workspace.workspace_dir
       staging_task.container.should_receive(:create_container).
@@ -678,7 +680,8 @@ YAML
              limit_memory: staging_task.memory_limit_in_bytes,
              setup_inbound_network: with_network,
              egress_rules: staging_task.staging_message.egress_rules,
-             rootfs: rootfs).ordered
+             rootfs: rootfs,
+             limit_bandwidth: expected_bandwidth).ordered
       %w(
         promise_app_download
         promise_prepare_staging_log


### PR DESCRIPTION
All containers will inherit the (optionally) configured bandwidth limit.
If no limit is configured, no limit will be applied.