### PR TITLE
Add support for config_vars 

### DIFF
--- a/buildpacks/lib/buildpack.rb
+++ b/buildpacks/lib/buildpack.rb
@@ -91,10 +91,11 @@ module Buildpacks
       buildpack_info = {
         "buildpack_path" => build_pack.path,
         "detected_buildpack" => build_pack.name,
+        "config_vars" => release_info["config_vars"],
         "start_command" => start_command,
         "effective_procfile" => effective_procfile
       }
-
+ 
       File.open(staging_info_path, 'w') do |f|
         YAML.dump(buildpack_info, f)
       end
@@ -133,7 +134,7 @@ module Buildpacks
     private
 
     def release_info
-      build_pack.release_info
+      @release_info ||= build_pack.release_info
     end
 
     def installers

--- a/lib/dea/env.rb
+++ b/lib/dea/env.rb
@@ -18,6 +18,7 @@ module Dea
     WHITELIST_SERVICE_KEYS = %W[name label tags plan plan_option credentials syslog_drain_url].freeze
 
     attr_reader :strategy_env
+    attr_writer :buildpack_environment_variables
 
     def initialize(message, instance_or_staging_task, env_exporter = Exporter, env_strategy_chooser = StrategyChooser.new(message, instance_or_staging_task))
       @env_exporter = env_exporter
@@ -26,6 +27,10 @@ module Dea
 
     def message
       strategy_env.message
+    end
+
+    def exported_buildpack_environment_variables
+      to_export(@buildpack_environment_variables || {})
     end
 
     def exported_system_environment_variables

--- a/lib/dea/starting/instance.rb
+++ b/lib/dea/starting/instance.rb
@@ -445,10 +445,13 @@ module Dea
             next
           end
 
+          env.buildpack_environment_variables = staged_info['config_vars']
+
           start_script =
             Dea::StartupScriptGenerator.new(
               command,
               env.exported_user_environment_variables,
+              env.exported_buildpack_environment_variables,
               env.exported_system_environment_variables,
               bootstrap.config.post_setup_hook
             ).generate

--- a/lib/dea/starting/startup_script_generator.rb
+++ b/lib/dea/starting/startup_script_generator.rb
@@ -24,17 +24,20 @@ module Dea
       exec bash -c %s
     BASH
 
-    def initialize(start_command, user_envs, system_envs, post_setup_hook)
+    def initialize(start_command, user_envs, buildpack_envs, system_envs, post_setup_hook)
       @start_command = start_command
       @user_envs = user_envs
+      @buildpack_envs = buildpack_envs
       @system_envs = system_envs
       @post_setup_hook = post_setup_hook
     end
 
     def generate
+      puts @buildpack_envs
       script = []
       script << "umask 077"
       script << @system_envs
+      script << @buildpack_envs
       script << @user_envs
       script << EXPORT_BUILDPACK_ENV_VARIABLES_SCRIPT
       script << @post_setup_hook unless @post_setup_hook.nil? || @post_setup_hook == ''

--- a/spec/unit/buildpack/buildpack_spec.rb
+++ b/spec/unit/buildpack/buildpack_spec.rb
@@ -150,10 +150,14 @@ describe Buildpacks::Buildpack, type: :buildpack do
 
       it "has the detected buildpack" do
         expect(buildpack_info["detected_buildpack"]).to eq("Node.js")
-      end
+      end      
 
       it "has the buildpack path" do
         expect(buildpack_info["buildpack_path"]).to eq("#{fake_buildpacks_dir}/no_start_command")
+      end
+
+      it "has the config vars" do
+        expect(buildpack_info["config_vars"]).to eq({"PATH"=>"bin:/usr/local/bin:/usr/bin:/bin", "FROM_BUILD_PACK"=>"yes"})
       end
 
       it "has a nil specified_buildpack_key" do

--- a/spec/unit/starting/instance_spec.rb
+++ b/spec/unit/starting/instance_spec.rb
@@ -825,6 +825,7 @@ describe Dea::Instance do
         double('environment 1',
                exported_environment_variables: 'system="sytem_value";\nexport user="user_value";\n',
                exported_user_environment_variables: 'user="user_value";\n',
+               exported_buildpack_environment_variables: 'config_var="config_var_value";\n',
                exported_system_environment_variables: 'system="sytem_value";\n'
         )
       end
@@ -834,6 +835,7 @@ describe Dea::Instance do
         allow(instance).to receive(:promise_start).and_call_original
         allow(instance).to receive(:staged_info)
         instance.attributes['warden_handle'] = 'handle'
+        allow(env).to receive(:buildpack_environment_variables=).with(nil)
         allow(Dea::Env).to receive(:new).and_return(env)
         allow(Dea::StartupScriptGenerator).to receive(:new).and_return(generator)
         allow(instance.container).to receive(:update_path_and_ip)
@@ -871,6 +873,7 @@ describe Dea::Instance do
             expect(Dea::StartupScriptGenerator).to receive(:new).with(
             'fake_start_command.sh',
             env.exported_user_environment_variables,
+            env.exported_buildpack_environment_variables,
             env.exported_system_environment_variables,
             'post-setup-hook',
             ).and_return(generator)

--- a/spec/unit/starting/instance_spec.rb
+++ b/spec/unit/starting/instance_spec.rb
@@ -823,10 +823,10 @@ describe Dea::Instance do
       let(:response) { double('spawn_response', job_id: 37) }
       let(:env) do
         double('environment 1',
-               exported_environment_variables: 'system="sytem_value";\nexport user="user_value";\n',
+               exported_environment_variables: 'system="system_value";\nexport user="user_value";\n',
                exported_user_environment_variables: 'user="user_value";\n',
                exported_buildpack_environment_variables: 'config_var="config_var_value";\n',
-               exported_system_environment_variables: 'system="sytem_value";\n'
+               exported_system_environment_variables: 'system="system_value";\n'
         )
       end
       let(:generator) { double('script generator', generate: 'dostuffscript') }

--- a/spec/unit/starting/startup_script_generator_spec.rb
+++ b/spec/unit/starting/startup_script_generator_spec.rb
@@ -3,12 +3,13 @@ require "dea/starting/startup_script_generator"
 
 describe Dea::StartupScriptGenerator do
   let(:user_envs) { %Q{export usr1="usrval1";\nexport usr2="usrval2";\nunset unset_var;\n} }
+  let(:buildpack_envs) { %Q{export bp1="bpval1";\nexport bp2="bpval2";\n} }
   let(:system_envs) { %Q{export usr1="sys_user_val1";\nexport sys1="sysval1";\n} }
   let(:used_buildpack) { '' }
   let(:start_command) { "go_nuts 'man' ; echo 'wooooohooo'" }
   let(:post_setup_hook) { "command1; command2" }
 
-  let(:generator) { Dea::StartupScriptGenerator.new(start_command, user_envs, system_envs, post_setup_hook) }
+  let(:generator) { Dea::StartupScriptGenerator.new(start_command, user_envs, buildpack_envs, system_envs, post_setup_hook) }
 
   describe "#generate" do
     subject(:script) { generator.generate }
@@ -24,6 +25,10 @@ describe Dea::StartupScriptGenerator do
         expect(script).to include user_envs
       end
 
+      it "exports the buildpack env variables" do
+        expect(script).to include buildpack_envs
+      end
+
       it "exports the system env variables" do
         expect(script).to include system_envs
       end
@@ -33,15 +38,15 @@ describe Dea::StartupScriptGenerator do
         expect(script).to include ". $i"
       end
 
-      it "exports user variables after system variables" do
-        expect(script).to match /usr1="sys_user_val1".*usr1="usrval1"/m
+      it "exports user after buildpack after system variables" do
+        expect(script).to match /usr1="sys_user_val1".*bp1="bpval1".*usr1="usrval1"/m
       end
 
-      it "exports build pack variables after system variables" do
+      it "exports system variables after system variables" do
         expect(script).to match /"sysval1".*\.profile\.d/m
       end
 
-      it "exports build pack variables after user variables" do
+      it "exports system variables after user variables" do
         expect(script).to match /usrval1.*\.profile\.d/m
       end
     end


### PR DESCRIPTION
Hello,

In https://docs.cloudfoundry.org/buildpacks/custom.html#release-script is mentioned that config_vars can be used by buildpacks to provide environment variables to applications. I've searched around the source code and I've found that it is not implemented. 

I've created an implementation for it reusing and integrating into the exist concepts of Buildpacks::Buildpack, Dea::StartupScriptGenerator and Dea::Env. 

One of the weak points of the solution is in Dea::Env - attr_writer :buildpack_environment_variables, there's no 'easy way' to pass the config_vars from the promise_start to the Env object. One of the possible solution was to use the already passed instance_or_staging_task in the initialize method, however using it would require some ugly is_a? checks to find out if it is Dea::Instance.

I could not find how to report these environment variables through the cf env command. I'll continue searching, but I would really appreciate help to finish this one as well.

Best Regards,
Dimitar