### PR TITLE
Add mem_used_bytes and mem_free_bytes metrics

### DIFF
--- a/lib/dea/bootstrap.rb
+++ b/lib/dea/bootstrap.rb
@@ -495,6 +495,8 @@ module Dea
       Dea::Loggregator.emit_value('instances', instance_registry.size, 'instances')
       Dea::Loggregator.emit_value('reservable_stagers', resource_manager.number_reservable(mem_required, disk_required), 'stagers')
       Dea::Loggregator.emit_value('avg_cpu_load', resource_manager.cpu_load_average, 'loadavg')
+      Dea::Loggregator.emit_value('mem_used_bytes', resource_manager.memory_used_bytes, 'B')
+      Dea::Loggregator.emit_value('mem_free_bytes', resource_manager.memory_free_bytes, 'B')
 
       instance_registry.emit_metrics_state
       instance_registry.emit_container_stats

--- a/lib/dea/resource_manager.rb
+++ b/lib/dea/resource_manager.rb
@@ -82,6 +82,16 @@ module Dea
        Vmstat.load_average.one_minute
     end
 
+    def memory_used_bytes
+      mem = Vmstat.memory
+      mem.active_bytes + mem.wired_bytes
+    end
+
+    def memory_free_bytes
+      mem = Vmstat.memory
+      mem.inactive_bytes + mem.free_bytes
+    end
+
     private
 
     def total_mb(registry, resource_name)

--- a/spec/unit/bootstrap_spec.rb
+++ b/spec/unit/bootstrap_spec.rb
@@ -394,6 +394,8 @@ describe Dea::Bootstrap do
       expect(bootstrap.resource_manager).to receive(:available_memory_ratio).and_return(0.22)
       expect(bootstrap.resource_manager).to receive(:available_disk_ratio).and_return(0.86)
       expect(bootstrap.resource_manager).to receive(:cpu_load_average).and_return(0.15)
+      expect(bootstrap.resource_manager).to receive(:memory_used_bytes).and_return(1000)
+      expect(bootstrap.resource_manager).to receive(:memory_free_bytes).and_return(100)
 
       expect(bootstrap.instance_registry).to receive(:emit_metrics_state)
       expect(bootstrap.instance_registry).to receive(:emit_container_stats)
@@ -409,6 +411,8 @@ describe Dea::Bootstrap do
       expect(@emitter.messages['available_memory_ratio']).to eq([{value: 0.22, unit: 'P'}])
       expect(@emitter.messages['available_disk_ratio']).to eq([{value: 0.86, unit: 'P'}])
       expect(@emitter.messages['avg_cpu_load']).to eq([{value: 0.15, unit: 'loadavg'}])
+      expect(@emitter.messages['mem_used_bytes']).to eq([{value: 1000, unit: 'B'}])
+      expect(@emitter.messages['mem_free_bytes']).to eq([{value: 100, unit: 'B'}])
     end
   end
 

--- a/spec/unit/resource_manager_spec.rb
+++ b/spec/unit/resource_manager_spec.rb
@@ -243,4 +243,32 @@ describe Dea::ResourceManager do
       expect(manager.cpu_load_average).to eq(3)
     end
   end
+
+  describe '#memory_used_bytes' do
+    let(:mem) { double(Vmstat.memory) }
+
+    before do
+      allow(Vmstat).to receive(:memory).and_return(mem)
+      allow(mem).to receive(:active_bytes).and_return(40)
+      allow(mem).to receive(:wired_bytes).and_return(60)
+    end
+
+    it 'returns the sum of active and wired bytes' do
+      expect(manager.memory_used_bytes).to eq(100)
+    end
+  end
+
+  describe '#memory_free_bytes' do
+    let(:mem) { double(Vmstat.memory) }
+
+    before do
+      allow(Vmstat).to receive(:memory).and_return(mem)
+      allow(mem).to receive(:inactive_bytes).and_return(300)
+      allow(mem).to receive(:free_bytes).and_return(700)
+    end
+
+    it 'returns the sum of inactive and free bytes' do
+      expect(manager.memory_free_bytes).to eq(1000)
+    end
+  end
 end


### PR DESCRIPTION
For monitoring it is helpful to have the real memory usage of DEAs. These metrics were available in cf < v232 via the collector.

Signed-off-by: Philipp Thun <philipp.thun@sap.com>