### PR TITLE
Avoid recreation of routes when avacuating

### DIFF
--- a/lib/dea/bootstrap.rb
+++ b/lib/dea/bootstrap.rb
@@ -401,7 +401,7 @@ module Dea
 
     def register_routes
       instance_registry.each do |instance|
-        next if !(instance.running? || instance.evacuating?) || instance.application_uris.empty?
+        next if !instance.running? || instance.application_uris.empty?
         router_client.register_instance(instance)
       end
 


### PR DESCRIPTION
DEA shoud not try to register an evacuating insance on routers.

Issue: https://github.com/cloudfoundry/dea_ng/issues/202